### PR TITLE
Fix VitePress base path for custom domain

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   title: "n-dx",
   description: "AI-powered development toolkit",
-  base: "/n-dx/",
+  base: "/",
 
   head: [
-    ["link", { rel: "icon", type: "image/png", href: "/n-dx/n-dx-logo.png" }],
+    ["link", { rel: "icon", type: "image/png", href: "/n-dx-logo.png" }],
     ["script", { async: "", src: "https://www.googletagmanager.com/gtag/js?id=G-C1ZPPSFEZD" }],
     ["script", {}, "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-C1ZPPSFEZD')"],
   ],


### PR DESCRIPTION
## Summary
- Fix VitePress base path from `/n-dx/` to `/` for custom domain `docs.n-dx.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)