### PR TITLE
Add gateway-rules.json to published files, bump to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AI-powered development toolkit — analyze a codebase, build a PRD, and execute tasks autonomously",
   "type": "module",
   "keywords": [
@@ -48,6 +48,7 @@
     "ci.js",
     "web.js",
     "help.js",
+    "gateway-rules.json",
     "refresh-plan.js",
     "refresh-artifacts.js",
     "export.js",


### PR DESCRIPTION
Missing from files array — causes ENOENT crash on ndx start when installed from npm.