### PR TITLE
Fix CI: update lockfile for typescript dep move

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       pdfkit:
         specifier: ^0.17.2
         version: 0.17.2
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
       zod:
         specifier: ^3.22.0
         version: 3.25.76
@@ -127,9 +130,6 @@ importers:
       '@types/pdfkit':
         specifier: ^0.17.4
         version: 0.17.4
-      typescript:
-        specifier: ^5.3.0
-        version: 5.9.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.0)(jsdom@27.4.0)


### PR DESCRIPTION
## Summary
- Regenerate `pnpm-lock.yaml` after moving `typescript` from `devDependencies` to `dependencies` in sourcevision (runtime dep for AST-based analyzers)
- All three CI workflows (CI, Release, Deploy Documentation) failed with `ERR_PNPM_OUTDATED_LOCKFILE`

## Test plan
- [ ] CI passes with `--frozen-lockfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)