### PR TITLE
Fix Release workflow: remove @n-dx/core from changesets fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
   "commit": false,
   "fixed": [
-    ["@n-dx/core", "@n-dx/rex", "@n-dx/hench", "@n-dx/sourcevision", "@n-dx/llm-client", "@n-dx/web"]
+    ["@n-dx/rex", "@n-dx/hench", "@n-dx/sourcevision", "@n-dx/llm-client", "@n-dx/web"]
   ],
   "linked": [],
   "access": "public",


### PR DESCRIPTION
## Summary
- Remove `@n-dx/core` from the changesets `fixed` group — it's the workspace root, not a workspace member, so changesets can't resolve it
- This caused the Release workflow to fail with `ValidationError: The package or glob expression "@n-dx/core" does not match any package`

## Test plan
- [ ] Release workflow passes (no changesets validation error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)