### PR TITLE
Fix MCP stdio registration for npm installs, enhance /work skill

### DIFF
--- a/claude-integration.js
+++ b/claude-integration.js
@@ -12,12 +12,27 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
+import { createRequire } from "module";
 import { join, resolve } from "path";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
 
 const __dir = dirname(fileURLToPath(import.meta.url));
+const _require = createRequire(import.meta.url);
+
+/**
+ * Resolve a sub-package CLI path — monorepo first, then node_modules.
+ */
+function resolveSubPackageCli(pkgDir, npmName) {
+  const monoPath = resolve(__dir, pkgDir, "dist/cli/index.js");
+  if (existsSync(monoPath)) return monoPath;
+  try {
+    return _require.resolve(npmName + "/dist/cli/index.js");
+  } catch {
+    return monoPath; // fallback — will fail with a clear error
+  }
+}
 
 // ── Permission tiers ──────────────────────────────────────────────────────────
 
@@ -130,14 +145,17 @@ argument-hint: "[task-id]"
 
 Pick up a task from the PRD and begin working on it.
 
-1. If task-id provided, call \`get_item\` (rex MCP). Otherwise call \`get_next_task\` (rex MCP)
-2. Read task details: title, description, acceptance criteria, parent chain
-3. For files mentioned in the task, use \`get_file_info\` and \`get_imports\` (sourcevision MCP) to understand current state
-4. Use \`get_zone\` (sourcevision MCP) for the relevant architectural zone
-5. Present a work plan: what needs to change, which files, what tests
-6. After user approves the plan, call \`update_task_status\` (rex MCP) to mark as \`in_progress\`
-7. Implement the changes
-8. When done, use \`update_task_status\` (rex MCP) to mark as \`completed\`
+1. Read \`.rex/workflow.md\` for the project's execution workflow. Follow its instructions — they define the expected discipline for task execution (TDD, validation, commit conventions, etc.)
+2. If task-id provided, call \`get_item\` (rex MCP). Otherwise call \`get_next_task\` (rex MCP)
+3. Read task details: title, description, acceptance criteria, parent chain
+4. For files mentioned in the task, use \`get_file_info\` and \`get_imports\` (sourcevision MCP) to understand current state
+5. Use \`get_zone\` (sourcevision MCP) for the relevant architectural zone
+6. Present a work plan: what needs to change, which files, what tests
+7. After user approves the plan, call \`update_task_status\` (rex MCP) to mark as \`in_progress\`
+8. Implement the changes following the workflow discipline
+9. Run validation and tests as specified in the workflow
+10. Call \`append_log\` (rex MCP) with what was done, decisions made, and issues encountered
+11. When done, use \`update_task_status\` (rex MCP) to mark as \`completed\`
 `,
 
   configure: `---
@@ -243,8 +261,8 @@ function registerMcpServers(dir) {
   const results = [];
 
   // Always use stdio — it doesn't require a running server
-  const rexBin = resolve(__dir, "packages/rex/dist/cli/index.js");
-  const svBin = resolve(__dir, "packages/sourcevision/dist/cli/index.js");
+  const rexBin = resolveSubPackageCli("packages/rex", "@n-dx/rex");
+  const svBin = resolveSubPackageCli("packages/sourcevision", "@n-dx/sourcevision");
   const absDir = resolve(dir);
 
   try {

--- a/claude-integration.js
+++ b/claude-integration.js
@@ -11,7 +11,7 @@
  * @module n-dx/claude-integration
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmdirSync, unlinkSync } from "fs";
 import { createRequire } from "module";
 import { join, resolve } from "path";
 import { execSync } from "child_process";
@@ -69,8 +69,8 @@ const AUTO_APPROVED_TOOLS = [
  * Keys are directory names; values are SKILL.md content.
  */
 const SKILLS = {
-  plan: `---
-name: plan
+  "ndx-plan": `---
+name: ndx-plan
 description: Analyze the codebase and propose PRD updates
 ---
 
@@ -86,8 +86,8 @@ Analyze the codebase and propose PRD updates.
 8. Show the updated PRD tree via \`get_prd_status\`
 `,
 
-  status: `---
-name: status
+  "ndx-status": `---
+name: ndx-status
 description: Show comprehensive project status combining PRD progress and codebase health
 ---
 
@@ -101,8 +101,8 @@ Show comprehensive project status combining PRD progress and codebase health.
 6. Present a unified report: progress, health, critical findings, and next steps
 `,
 
-  capture: `---
-name: capture
+  "ndx-capture": `---
+name: ndx-capture
 description: Capture a requirement, feature idea, or task from conversation context
 argument-hint: "[description]"
 ---
@@ -121,8 +121,8 @@ Capture a requirement, feature idea, or task from conversation context.
 7. Use \`add_item\` (rex MCP) to create, then confirm placement in hierarchy
 `,
 
-  zone: `---
-name: zone
+  "ndx-zone": `---
+name: ndx-zone
 description: Deep-dive into an architectural zone's structure and health
 argument-hint: "[zone-id]"
 ---
@@ -137,8 +137,8 @@ Deep-dive into an architectural zone's structure and health.
 6. Present: zone purpose, key files, cohesion/coupling metrics, findings, and cross-zone dependencies
 `,
 
-  work: `---
-name: work
+  "ndx-work": `---
+name: ndx-work
 description: Pick up a task from the PRD and begin working on it
 argument-hint: "[task-id]"
 ---
@@ -158,8 +158,8 @@ Pick up a task from the PRD and begin working on it.
 11. When done, use \`update_task_status\` (rex MCP) to mark as \`completed\`
 `,
 
-  configure: `---
-name: configure
+  "ndx-config": `---
+name: ndx-config
 description: View or change n-dx configuration with guided assistance
 argument-hint: "[key] [value]"
 ---
@@ -225,9 +225,26 @@ function mergeSettings(dir) {
  * Overwrites existing skill files (they're n-dx-managed).
  * Also cleans up old flat-file format (`.claude/skills/<name>.md`).
  */
+/** Old unprefixed skill names — removed on init to avoid duplicates. */
+const LEGACY_SKILL_NAMES = ["plan", "status", "capture", "zone", "work", "configure"];
+
 function writeSkills(dir) {
   const skillsDir = join(dir, ".claude", "skills");
   mkdirSync(skillsDir, { recursive: true });
+
+  // Clean up legacy unprefixed skill directories
+  for (const old of LEGACY_SKILL_NAMES) {
+    const oldDir = join(skillsDir, old);
+    if (existsSync(join(oldDir, "SKILL.md"))) {
+      try { unlinkSync(join(oldDir, "SKILL.md")); } catch { /* ignore */ }
+      try { rmdirSync(oldDir); } catch { /* ignore — may have user files */ }
+    }
+    // Also clean up old flat-file format
+    const oldFlat = join(skillsDir, `${old}.md`);
+    if (existsSync(oldFlat)) {
+      try { unlinkSync(oldFlat); } catch { /* ignore */ }
+    }
+  }
 
   let written = 0;
   for (const [name, content] of Object.entries(SKILLS)) {
@@ -330,7 +347,7 @@ export function printClaudeSetupSummary(result) {
   }
 
   // Skills
-  console.log(`  Skills: wrote ${result.skills.written} workflow skills (/plan, /status, /capture, /zone, /work, /configure)`);
+  console.log(`  Skills: wrote ${result.skills.written} workflow skills (/ndx-plan, /ndx-status, /ndx-capture, /ndx-zone, /ndx-work, /ndx-config)`);
 
   // MCP
   if (!result.mcp.registered) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AI-powered development toolkit — analyze a codebase, build a PRD, and execute tasks autonomously",
   "type": "module",
   "keywords": [

--- a/packages/hench/package.json
+++ b/packages/hench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n-dx/hench",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm-client/package.json
+++ b/packages/llm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n-dx/llm-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rex/package.json
+++ b/packages/rex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n-dx/rex",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sourcevision/package.json
+++ b/packages/sourcevision/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n-dx/sourcevision",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Elastic-2.0",
   "description": "Codebase analysis tool with structured, git-friendly output",
   "publishConfig": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n-dx/web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Elastic-2.0",
   "description": "n-dx web dashboard — serves sourcevision, rex, and hench data",
   "publishConfig": {


### PR DESCRIPTION
- resolveSubPackageCli: try monorepo path first, fall back to node_modules — fixes broken MCP server paths after npm i -g
- /work skill now reads .rex/workflow.md first and follows its execution discipline (TDD, validation, logging, etc.)