### PR TITLE
Fix Release: add NODE_AUTH_TOKEN for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@
 # 2. The "Version Packages" PR is auto-created/updated with bumped versions + changelog
 # 3. Merging the "Version Packages" PR triggers npm publish + git tags
 #
-# Uses npm trusted publishing (OIDC) — no NPM_TOKEN secret needed.
-# Configure trusted publishing at npmjs.com → package settings → Publishing access.
+# Requires NPM_TOKEN secret (granular access token scoped to @n-dx/*).
+# Create at npmjs.com → Access Tokens → Granular Access Token.
 
 name: Release
 
@@ -58,4 +58,5 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the changesets publish step
- `setup-node` writes `.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` — without this env var set, the token is empty and npm returns 404 on PUT
- OIDC trusted publishing alone doesn't work with the changesets action ([#311](https://github.com/changesets/action/issues/311), [#98](https://github.com/changesets/action/issues/98))

## Setup required
1. Create a granular access token on npmjs.com scoped to `@n-dx/*` (read + write)
2. Add it as `NPM_TOKEN` secret in repo Settings → Secrets → Actions

## Test plan
- [ ] Merge to main and verify Release workflow publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)