### PR TITLE
Add repository field to package.json files for npm provenance

### DIFF
--- a/packages/hench/package.json
+++ b/packages/hench/package.json
@@ -5,6 +5,11 @@
     "access": "public"
   },
   "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/en-dash-consulting/n-dx.git",
+    "directory": "packages/hench"
+  },
   "type": "module",
   "bin": {
     "hench": "./dist/cli/index.js"

--- a/packages/llm-client/package.json
+++ b/packages/llm-client/package.json
@@ -5,6 +5,11 @@
     "access": "public"
   },
   "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/en-dash-consulting/n-dx.git",
+    "directory": "packages/llm-client"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/rex/package.json
+++ b/packages/rex/package.json
@@ -5,6 +5,11 @@
     "access": "public"
   },
   "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/en-dash-consulting/n-dx.git",
+    "directory": "packages/rex"
+  },
   "type": "module",
   "bin": {
     "rex": "./dist/cli/index.js"

--- a/packages/sourcevision/package.json
+++ b/packages/sourcevision/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.7",
   "license": "Elastic-2.0",
   "description": "Codebase analysis tool with structured, git-friendly output",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/en-dash-consulting/n-dx.git",
+    "directory": "packages/sourcevision"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.7",
   "license": "Elastic-2.0",
   "description": "n-dx web dashboard — serves sourcevision, rex, and hench data",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/en-dash-consulting/n-dx.git",
+    "directory": "packages/web"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Add `repository` field to all 5 published package.json files
- Required by npm sigstore provenance verification — publish was failing with E422 because `repository.url` was empty

## Test plan
- [x] Verify each package.json has correct `repository.url` and `directory` values
- [ ] Re-run release workflow after merge to confirm provenance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)