### PR TITLE
Include @n-dx/core in changeset releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
   "commit": false,
   "fixed": [
-    ["@n-dx/rex", "@n-dx/hench", "@n-dx/sourcevision", "@n-dx/llm-client", "@n-dx/web"]
+    ["@n-dx/core", "@n-dx/rex", "@n-dx/hench", "@n-dx/sourcevision", "@n-dx/llm-client", "@n-dx/web"]
   ],
   "linked": [],
   "access": "public",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "AI-powered development toolkit — analyze a codebase, build a PRD, and execute tasks autonomously",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- Add `@n-dx/core` to the changeset `fixed` group so it versions alongside all other packages
- Bump `@n-dx/core` from 0.1.7 → 0.1.8 to match the current release

## Context
The root package (`@n-dx/core`) was omitted from the `fixed` array in `.changeset/config.json`, so its version stayed at 0.1.7 while the other packages moved to 0.1.8. Merging this PR will also trigger the release workflow to publish `@n-dx/core@0.1.8` to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)