### PR TITLE
Sync @n-dx/core version and publish via release workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
   "commit": false,
   "fixed": [
-    ["@n-dx/core", "@n-dx/rex", "@n-dx/hench", "@n-dx/sourcevision", "@n-dx/llm-client", "@n-dx/web"]
+    ["@n-dx/rex", "@n-dx/hench", "@n-dx/sourcevision", "@n-dx/llm-client", "@n-dx/web"]
   ],
   "linked": [],
   "access": "public",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,29 @@ jobs:
         run: pnpm build
 
       - name: Create Release PR or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version
+          version: pnpm changeset version && node scripts/sync-root-version.js
           publish: pnpm changeset publish --access public
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Publish @n-dx/core (root package)
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          NPM_VERSION=$(npm view @n-dx/core version 2>/dev/null || echo "0.0.0")
+          if [ "$CURRENT" != "$NPM_VERSION" ]; then
+            echo "Publishing @n-dx/core@$CURRENT (npm has $NPM_VERSION)"
+            npm publish --access public --provenance
+          else
+            echo "@n-dx/core@$CURRENT already published, skipping"
+          fi
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/scripts/sync-root-version.js
+++ b/scripts/sync-root-version.js
@@ -1,0 +1,21 @@
+/**
+ * Sync root package.json version with workspace packages.
+ *
+ * Changesets can't manage the root package (it's the workspace root, not a
+ * workspace member). This script runs after `pnpm changeset version` to
+ * copy the version from a workspace package (all are in a fixed group, so
+ * any one will do) into the root package.json.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const root = JSON.parse(readFileSync('package.json', 'utf8'));
+const ref = JSON.parse(readFileSync('packages/rex/package.json', 'utf8'));
+
+if (root.version !== ref.version) {
+  root.version = ref.version;
+  writeFileSync('package.json', JSON.stringify(root, null, 2) + '\n');
+  console.log(`@n-dx/core version synced to ${ref.version}`);
+} else {
+  console.log(`@n-dx/core already at ${root.version}, no sync needed`);
+}


### PR DESCRIPTION
The root package isn't a pnpm workspace member, so changesets can't manage it directly. Instead:
- After `changeset version`, sync root version from workspace packages
- After `changeset publish`, publish root package if version changed