### PR TITLE
Fix release: patch bump (not minor) and skip prepublishOnly in CI

### DIFF
--- a/.changeset/self-heal-feedback-fixes.md
+++ b/.changeset/self-heal-feedback-fixes.md
@@ -1,6 +1,6 @@
 ---
-"@n-dx/sourcevision": minor
-"@n-dx/rex": minor
+"@n-dx/sourcevision": patch
+"@n-dx/rex": patch
 "@n-dx/web": patch
 ---
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "validate": "pnpm -r run validate",
     "verify": "vitest run tests/e2e && node ci.js .",
     "pr-check": "node pr-check.js",
-    "prepublishOnly": "pnpm run build && pnpm run typecheck && pnpm run test",
+    "prepublishOnly": "if [ -z \"$CI\" ]; then pnpm run build && pnpm run typecheck && pnpm run test; fi",
     "prepare": "pnpm run build",
     "changeset": "changeset",
     "version-packages": "changeset version",


### PR DESCRIPTION
- Downgrade changeset from minor to patch for sourcevision and rex
- Skip prepublishOnly in CI: npm publish was triggering full build + typecheck + test suite redundantly, causing 20-minute timeout (Go integration tests are slow). CI already validates separately.