### PR TITLE
Fix cli timeout config being silently ignored when stored as string

### DIFF
--- a/.changeset/fix-cli-timeout-string-coercion.md
+++ b/.changeset/fix-cli-timeout-string-coercion.md
@@ -1,0 +1,9 @@
+---
+"@n-dx/core": patch
+---
+
+Fix `cli.timeouts.<command>` being silently ignored when stored as a string
+
+- `ndx config cli.timeouts.work <ms>` now stores the value as a number (numeric-shaped strings and `"true"`/`"false"` are auto-coerced when setting a brand-new key)
+- `resolveCommandTimeout` accepts numeric strings defensively, so existing configs that were written as strings by earlier versions start working without a re-set
+- `ndx init` runs a new config-repair pass that rewrites known-numeric paths (`cli.timeoutMs`, `cli.timeouts.*`, `web.port`) as proper numbers and reports what was repaired

--- a/packages/core/cli-timeout.js
+++ b/packages/core/cli-timeout.js
@@ -25,6 +25,20 @@ export const DEFAULT_TIMEOUT_MS = 1800000;
 const NO_DEFAULT_TIMEOUT_COMMANDS = new Set(["start", "web", "dev"]);
 
 /**
+ * Coerce a config value to a finite non-negative number of milliseconds.
+ * Accepts both native numbers and numeric strings (e.g. "14400000") so
+ * manually-edited or legacy configs that stored numbers as strings still work.
+ * Returns NaN if the value cannot be interpreted as a timeout.
+ */
+function toTimeoutMs(value) {
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && /^-?\d+(\.\d+)?$/.test(value.trim())) {
+    return Number(value);
+  }
+  return NaN;
+}
+
+/**
  * Resolve the effective timeout for a CLI command.
  *
  * Priority (highest first):
@@ -43,15 +57,15 @@ export function resolveCommandTimeout(command, projectConfig) {
   const cli = projectConfig?.cli ?? {};
 
   // 1. Per-command override takes highest precedence
-  const perCommand = cli.timeouts?.[command];
-  if (typeof perCommand === "number") {
+  const perCommand = toTimeoutMs(cli.timeouts?.[command]);
+  if (Number.isFinite(perCommand)) {
     // Explicit 0 means "no timeout"; positive value is a timeout in ms
     return perCommand >= 0 ? perCommand : DEFAULT_TIMEOUT_MS;
   }
 
   // 2. Global CLI timeout override
-  const global = cli.timeoutMs;
-  if (typeof global === "number" && global >= 0) {
+  const global = toTimeoutMs(cli.timeoutMs);
+  if (Number.isFinite(global) && global >= 0) {
     return global;
   }
 

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -40,7 +40,7 @@ import { createRequire } from "module";
 import { dirname, isAbsolute, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { createInterface } from "readline/promises";
-import { runConfig, loadProjectConfig } from "./config.js";
+import { runConfig, loadProjectConfig, repairProjectConfig } from "./config.js";
 import { resolveCommandTimeout, withCommandTimeout } from "./cli-timeout.js";
 import { runCI } from "./ci.js";
 import {
@@ -749,13 +749,27 @@ async function handleInit(rest) {
   const initArgs = stripInitProviderFlag(rest).filter((a) => a !== "--no-claude");
   const dir = resolveDir(initArgs);
   const flags = extractFlags(initArgs);
+  const quiet = flags.includes("--quiet") || flags.includes("-q");
+
+  // Repair known-numeric config values that may have been stored as strings
+  // by earlier versions (e.g. cli.timeouts.work = "14400000"). Runs before
+  // anything reads the config so sub-package inits see well-typed values.
+  try {
+    const { repairs } = await repairProjectConfig(dir);
+    if (repairs.length > 0 && !quiet) {
+      console.log(`Repaired ${repairs.length} config value${repairs.length === 1 ? "" : "s"} in .n-dx.json:`);
+      for (const { path, from, to } of repairs) {
+        console.log(`  ${path}: "${from}" → ${to}`);
+      }
+    }
+  } catch {
+    // Non-fatal — repair failure never blocks init.
+  }
 
   // Check for existing provider config before prompting
   const existingVendor = readLLMVendor(dir);
   let selectedProvider;
   let providerSource;
-
-  const quiet = flags.includes("--quiet") || flags.includes("-q");
 
   if (providerFromFlag) {
     selectedProvider = providerFromFlag;

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -47,6 +47,13 @@ const PROJECT_SECTIONS = new Set([
  */
 const VALID_LANGUAGES = new Set(["typescript", "javascript", "go", "auto"]);
 
+/**
+ * Regex matching integer or simple decimal strings (positive or negative).
+ * Intentionally strict: rejects multi-dot strings like "1.2.3" so version
+ * strings are left as strings.
+ */
+const NUMERIC_STRING_RE = /^-?\d+(\.\d+)?$/;
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 async function fileExists(path) {
@@ -140,6 +147,70 @@ export async function loadProjectConfig(dir) {
   return merged;
 }
 
+/**
+ * Known config paths whose values must be finite numbers.
+ * Used by repairProjectConfig() to re-type string values that should have
+ * been stored as numbers (e.g. from first-time sets before coerceValue
+ * auto-detected numeric strings).
+ *
+ * Paths may use "*" as a final segment to match any key under an object.
+ */
+const NUMERIC_CONFIG_PATHS = [
+  "cli.timeoutMs",
+  "cli.timeouts.*",
+  "web.port",
+];
+
+/**
+ * In-place: coerce string numeric values at known-numeric paths to numbers.
+ * Returns a list of { path, from, to } entries describing each repair.
+ */
+function applyNumericRepairs(obj) {
+  const repairs = [];
+  for (const path of NUMERIC_CONFIG_PATHS) {
+    const parts = path.split(".");
+    const leaf = parts[parts.length - 1];
+    const parent = getByPath(obj, parts.slice(0, -1).join("."));
+    if (parent == null || typeof parent !== "object") continue;
+
+    const entries = leaf === "*" ? Object.keys(parent) : [leaf];
+    for (const key of entries) {
+      const value = parent[key];
+      if (typeof value !== "string") continue;
+      if (!NUMERIC_STRING_RE.test(value)) continue;
+      const n = Number(value);
+      if (!Number.isFinite(n)) continue;
+      const displayPath = leaf === "*"
+        ? `${parts.slice(0, -1).join(".")}.${key}`
+        : path;
+      parent[key] = n;
+      repairs.push({ path: displayPath, from: value, to: n });
+    }
+  }
+  return repairs;
+}
+
+/**
+ * Scan the project-level .n-dx.json for values stored with the wrong JSON
+ * type (typically: numbers stored as strings by old write paths) and repair
+ * them in place. Only rewrites the file when repairs are found.
+ *
+ * Returns { repairs } — a list of { path, from, to } entries. An empty list
+ * means the config was already well-typed (or was missing).
+ */
+export async function repairProjectConfig(dir) {
+  const configPath = join(dir, PROJECT_CONFIG_FILE);
+  const current = await loadProjectConfigFile(dir, PROJECT_CONFIG_FILE);
+  if (!current || Object.keys(current).length === 0) {
+    return { repairs: [] };
+  }
+  const repairs = applyNumericRepairs(current);
+  if (repairs.length > 0) {
+    await saveProjectJSON(configPath, current);
+  }
+  return { repairs };
+}
+
 function isLocalProjectSetting(pkg, settingPath) {
   if (pkg === "claude") return settingPath === "cli_path";
   if (pkg === "llm") return settingPath.endsWith(".cli_path");
@@ -182,10 +253,22 @@ function setByPath(obj, path, value) {
  * - If existing is a number, parse as number
  * - If existing is a boolean, parse as boolean
  * - If existing is an array, split on commas
+ * - If existing is undefined/null, auto-detect: numeric-shaped strings become
+ *   numbers, "true"/"false" become booleans, anything else stays a string.
+ *   This ensures first-time sets of numeric keys (e.g. cli.timeouts.work) are
+ *   stored with the correct JSON type instead of as a string.
  * - Otherwise keep as string
  */
 function coerceValue(newValue, existingValue) {
   if (existingValue === undefined || existingValue === null) {
+    if (typeof newValue === "string") {
+      if (NUMERIC_STRING_RE.test(newValue)) {
+        const n = Number(newValue);
+        if (Number.isFinite(n)) return n;
+      }
+      if (newValue === "true") return true;
+      if (newValue === "false") return false;
+    }
     return newValue;
   }
   if (typeof existingValue === "number") {

--- a/tests/unit/cli-timeout.test.js
+++ b/tests/unit/cli-timeout.test.js
@@ -58,6 +58,23 @@ describe("resolveCommandTimeout", () => {
     // Negative is not a valid timeout; falls back to DEFAULT_TIMEOUT_MS
     expect(resolveCommandTimeout("analyze", cfg)).toBe(DEFAULT_TIMEOUT_MS);
   });
+
+  it("accepts per-command override stored as a numeric string", () => {
+    // Legacy configs may store the value as a string (e.g. from the first
+    // `ndx config cli.timeouts.work 14400000` where existingValue was undefined).
+    const cfg = { cli: { timeouts: { work: "14400000" } } };
+    expect(resolveCommandTimeout("work", cfg)).toBe(14400000);
+  });
+
+  it("accepts global cli.timeoutMs stored as a numeric string", () => {
+    const cfg = { cli: { timeoutMs: "5000" } };
+    expect(resolveCommandTimeout("analyze", cfg)).toBe(5000);
+  });
+
+  it("ignores non-numeric strings and falls back to the default", () => {
+    const cfg = { cli: { timeouts: { analyze: "lots" } } };
+    expect(resolveCommandTimeout("analyze", cfg)).toBe(DEFAULT_TIMEOUT_MS);
+  });
 });
 
 // ── withCommandTimeout ───────────────────────────────────────────────────────

--- a/tests/unit/config-repair.test.js
+++ b/tests/unit/config-repair.test.js
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { repairProjectConfig } from "../../packages/core/config.js";
+
+describe("repairProjectConfig", () => {
+  let dir;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ndx-repair-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeConfig(obj) {
+    await writeFile(join(dir, ".n-dx.json"), JSON.stringify(obj, null, 2));
+  }
+
+  async function readConfig() {
+    return JSON.parse(await readFile(join(dir, ".n-dx.json"), "utf-8"));
+  }
+
+  it("returns empty repairs when .n-dx.json is missing", async () => {
+    const { repairs } = await repairProjectConfig(dir);
+    expect(repairs).toEqual([]);
+  });
+
+  it("coerces cli.timeouts.<command> stored as a string to a number", async () => {
+    await writeConfig({ cli: { timeouts: { work: "14400000" } } });
+    const { repairs } = await repairProjectConfig(dir);
+
+    expect(repairs).toEqual([
+      { path: "cli.timeouts.work", from: "14400000", to: 14400000 },
+    ]);
+    const after = await readConfig();
+    expect(after.cli.timeouts.work).toBe(14400000);
+    expect(typeof after.cli.timeouts.work).toBe("number");
+  });
+
+  it("coerces cli.timeoutMs stored as a string", async () => {
+    await writeConfig({ cli: { timeoutMs: "60000" } });
+    const { repairs } = await repairProjectConfig(dir);
+
+    expect(repairs).toEqual([
+      { path: "cli.timeoutMs", from: "60000", to: 60000 },
+    ]);
+    expect((await readConfig()).cli.timeoutMs).toBe(60000);
+  });
+
+  it("repairs multiple entries under cli.timeouts", async () => {
+    await writeConfig({
+      cli: { timeouts: { work: "14400000", analyze: "60000", plan: 30000 } },
+    });
+    const { repairs } = await repairProjectConfig(dir);
+
+    expect(repairs.map((r) => r.path).sort()).toEqual([
+      "cli.timeouts.analyze",
+      "cli.timeouts.work",
+    ]);
+    const after = await readConfig();
+    expect(after.cli.timeouts.work).toBe(14400000);
+    expect(after.cli.timeouts.analyze).toBe(60000);
+    expect(after.cli.timeouts.plan).toBe(30000); // unchanged
+  });
+
+  it("leaves numeric values alone", async () => {
+    await writeConfig({ cli: { timeouts: { work: 14400000 } } });
+    const { repairs } = await repairProjectConfig(dir);
+    expect(repairs).toEqual([]);
+  });
+
+  it("leaves non-numeric strings alone (e.g. version-like)", async () => {
+    await writeConfig({ _initVersion: "0.2.2", cli: { timeouts: {} } });
+    const { repairs } = await repairProjectConfig(dir);
+    expect(repairs).toEqual([]);
+    expect((await readConfig())._initVersion).toBe("0.2.2");
+  });
+
+  it("does not rewrite the file when no repairs are needed", async () => {
+    const original = { cli: { timeouts: { work: 14400000 } } };
+    await writeConfig(original);
+    const before = await readFile(join(dir, ".n-dx.json"), "utf-8");
+    await repairProjectConfig(dir);
+    const after = await readFile(join(dir, ".n-dx.json"), "utf-8");
+    // Byte-for-byte identical — we didn't touch the file.
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
The first `ndx config cli.timeouts.work <ms>` wrote the value as a string because coerceValue left unknown keys as-is. resolveCommandTimeout then skipped it (typeof !== "number") and fell back to the 30-min default, so the "Increase the limit with: ndx config ..." hint in the timeout error reproduced the same bug.

- coerceValue now auto-detects type for new keys: numeric-shaped strings become numbers, "true"/"false" become booleans.
- resolveCommandTimeout accepts numeric strings defensively so existing broken configs start working without a re-set.
- ndx init runs a new repairProjectConfig() that rewrites known-numeric paths (cli.timeoutMs, cli.timeouts.*, web.port) as proper numbers and reports what was repaired.