### PR TITLE
Fix broken external links in landing page

### DIFF
--- a/.changeset/fix-landing-page-links.md
+++ b/.changeset/fix-landing-page-links.md
@@ -1,0 +1,5 @@
+---
+"@n-dx/web": patch
+---
+
+Fix broken external links in the landing page. GitHub links pointed to the old `endash/n-dx` org handle (now `en-dash-consulting/n-dx`) and the npm link pointed to the old unscoped `n-dx` package (now `@n-dx/core`). Updated all six occurrences including the inline security manifest comment.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@
 #
 # Node 22 LTS. Exact pnpm version managed by corepack via packageManager
 # field in package.json.
+#
+# Action versions: checkout@v6, setup-node@v6, pnpm/action-setup@v5 all run
+# on Node.js 24. upload-artifact@v4 and download-artifact@v4 are already on
+# Node.js 24 and do not require bumping.
 
 name: CI
 
@@ -25,13 +29,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -90,13 +94,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -125,13 +129,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -161,10 +165,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/packages/web/src/landing/index.html
+++ b/packages/web/src/landing/index.html
@@ -15,8 +15,8 @@
       - /Hench-F.png         (pipeline icon)
       - ./landing.css        (landing page stylesheet)
       - ./landing.ts         (landing page entry point, bundled by Vite)
-      - https://github.com/endash/n-dx  (outbound link only — not a loaded resource)
-      - https://www.npmjs.com/package/n-dx (outbound link only — not a loaded resource)
+      - https://github.com/en-dash-consulting/n-dx  (outbound link only — not a loaded resource)
+      - https://www.npmjs.com/package/@n-dx/core (outbound link only — not a loaded resource)
     If an external CDN resource is added here, register it in this block
     so that supply-chain security tooling can audit it alongside pnpm audit.
   -->
@@ -65,7 +65,7 @@
         </p>
         <div class="hero-actions fade-in">
           <a href="#get-started" class="btn btn-primary">Get Started</a>
-          <a href="https://github.com/endash/n-dx" class="btn btn-ghost" target="_blank" rel="noopener noreferrer">
+          <a href="https://github.com/en-dash-consulting/n-dx" class="btn btn-ghost" target="_blank" rel="noopener noreferrer">
             GitHub
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M4.5 11.5L11.5 4.5M11.5 4.5H5.5M11.5 4.5V10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </a>
@@ -289,17 +289,17 @@
 
         <!-- Links -->
         <div class="get-started-links fade-in">
-          <a href="https://github.com/endash/n-dx" class="gs-link" target="_blank" rel="noopener noreferrer">
+          <a href="https://github.com/en-dash-consulting/n-dx" class="gs-link" target="_blank" rel="noopener noreferrer">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
             <span>GitHub</span>
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true" class="gs-link-ext"><path d="M4.5 11.5L11.5 4.5M11.5 4.5H5.5M11.5 4.5V10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </a>
-          <a href="https://github.com/endash/n-dx#readme" class="gs-link" target="_blank" rel="noopener noreferrer">
+          <a href="https://github.com/en-dash-consulting/n-dx#readme" class="gs-link" target="_blank" rel="noopener noreferrer">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M2 3.5C2 2.67 2.67 2 3.5 2H9.38C9.77 2 10.15 2.15 10.43 2.44L13.56 5.57C13.84 5.85 14 6.23 14 6.62V12.5C14 13.33 13.33 14 12.5 14H3.5C2.67 14 2 13.33 2 12.5V3.5Z" stroke="currentColor" stroke-width="1.3"/><path d="M5 8H11M5 10.5H9" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
             <span>Documentation</span>
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true" class="gs-link-ext"><path d="M4.5 11.5L11.5 4.5M11.5 4.5H5.5M11.5 4.5V10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </a>
-          <a href="https://www.npmjs.com/package/n-dx" class="gs-link" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.npmjs.com/package/@n-dx/core" class="gs-link" target="_blank" rel="noopener noreferrer">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1" y="4" width="14" height="8" rx="1" stroke="currentColor" stroke-width="1.3"/><path d="M4.5 4.5V11.5M8 4.5V9.5M11.5 4.5V11.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
             <span>npm</span>
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true" class="gs-link-ext"><path d="M4.5 11.5L11.5 4.5M11.5 4.5H5.5M11.5 4.5V10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/tests/integration/scheduler-startup.test.js
+++ b/tests/integration/scheduler-startup.test.js
@@ -34,11 +34,11 @@ const {
   loadCleanupConfig,
   DEFAULT_CLEANUP_INTERVAL_MS,
 } = await import(
-  "../../packages/web/dist/server/usage-cleanup-scheduler.js"
+  "../../packages/web/dist/server/task-usage/usage-cleanup-scheduler.js"
 );
 
 const { registerUsageScheduler } = await import(
-  "../../packages/web/dist/server/register-scheduler.js"
+  "../../packages/web/dist/server/task-usage/register-scheduler.js"
 );
 
 // Import collectAllIds from rex to verify the cross-package data flow

--- a/tests/integration/web-server-viewer-boundary.test.js
+++ b/tests/integration/web-server-viewer-boundary.test.js
@@ -36,7 +36,7 @@ describe("web server shared types boundary", () => {
 
   it("register-scheduler exports the facade function", async () => {
     const mod = await import(
-      "../../packages/web/dist/server/register-scheduler.js"
+      "../../packages/web/dist/server/task-usage/register-scheduler.js"
     );
 
     expect(typeof mod.registerUsageScheduler).toBe("function");
@@ -44,7 +44,7 @@ describe("web server shared types boundary", () => {
 
   it("usage-cleanup-scheduler exports core functions", async () => {
     const mod = await import(
-      "../../packages/web/dist/server/usage-cleanup-scheduler.js"
+      "../../packages/web/dist/server/task-usage/usage-cleanup-scheduler.js"
     );
 
     expect(typeof mod.startUsageCleanupScheduler).toBe("function");
@@ -84,7 +84,7 @@ describe("web → rex gateway contract", () => {
 describe("cleanup data flow type compatibility", () => {
   it("identifyOrphanedEntries produces OrphanedEntry-compatible objects", async () => {
     const { identifyOrphanedEntries } = await import(
-      "../../packages/web/dist/server/usage-cleanup-scheduler.js"
+      "../../packages/web/dist/server/task-usage/usage-cleanup-scheduler.js"
     );
 
     const taskUsage = {
@@ -103,7 +103,7 @@ describe("cleanup data flow type compatibility", () => {
 
   it("DEFAULT_CLEANUP_INTERVAL_MS is 7 days in milliseconds", async () => {
     const { DEFAULT_CLEANUP_INTERVAL_MS } = await import(
-      "../../packages/web/dist/server/usage-cleanup-scheduler.js"
+      "../../packages/web/dist/server/task-usage/usage-cleanup-scheduler.js"
     );
 
     const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Changes

**Landing page link fixes** (`packages/web/src/landing/index.html`):
- GitHub: `github.com/endash/n-dx` → `github.com/en-dash-consulting/n-dx` (3 hrefs + manifest comment)
- npm: `npmjs.com/package/n-dx` → `npmjs.com/package/@n-dx/core` (href + manifest comment)

**CI: Bump GitHub Actions to Node.js 24** (deadline: June 2, 2026):
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `pnpm/action-setup@v4` → `@v5`

(`upload-artifact@v4` / `download-artifact@v4` are already on Node.js 24, no change needed.)

**Fix stale integration test import paths:**
- Scheduler files were moved to `server/task-usage/` in a prior PR; two root integration tests (`scheduler-startup.test.js`, `web-server-viewer-boundary.test.js`) still imported from the old `server/` path, causing failures.

## Test plan

- [x] `pnpm preflight` — all steps pass locally (build, typecheck, docs, pr-check, test, changeset)
- [x] Changeset included (`@n-dx/web: patch`)
- [x] Links verified in browser

Co-Authored-By: Oz <oz-agent@warp.dev>