### PR TITLE
  n-dx add nesting fix, dashboard Quick Add end-to-end, PRD tree decluttering

### DIFF
--- a/.changeset/accept-folder-tree-write.md
+++ b/.changeset/accept-folder-tree-write.md
@@ -1,0 +1,13 @@
+---
+"@n-dx/web": patch
+---
+
+Fix dashboard proposal acceptance silently dropping items. The
+`/api/rex/proposals/accept` and `/api/rex/proposals/accept-edited`
+handlers wrote new items via `savePRD` — which targets the legacy
+`prd.md` + ephemeral cache — instead of the folder tree
+(`.rex/prd_tree/`), the authoritative PRD surface per CLAUDE.md. The
+folder-tree watcher then rebuilt the cache from the unchanged tree, so
+accepted epics/features/tasks vanished with no error. Both handlers
+now write through `resolveStore().addItem()` and refresh the cache
+from the store so the dashboard sees the new items immediately.

--- a/.changeset/exec-close-stdin.md
+++ b/.changeset/exec-close-stdin.md
@@ -1,0 +1,11 @@
+---
+"@n-dx/llm-client": patch
+---
+
+Close the child's stdin immediately when calling `exec()`. `execFile`
+pipes stdio by default, but `exec` never writes to the child's stdin —
+leaving it open caused any spawned process that reads stdin (e.g.
+`rex add`'s `readStdin()` in non-TTY mode) to hang forever waiting for
+an EOF that would never arrive. This was the root cause of the
+dashboard Quick Add timing out at 240 s with zero output from a
+daemonized `ndx start`.

--- a/.changeset/haiku-model-id.md
+++ b/.changeset/haiku-model-id.md
@@ -1,0 +1,11 @@
+---
+"@n-dx/llm-client": patch
+---
+
+Correct the haiku model id. `TIER_MODELS.claude.light` and
+`MODEL_ALIASES.haiku` referenced `claude-haiku-4-20250414`, which doesn't
+exist — the API returns 404, but the Claude CLI provider hangs silently
+on the bad id instead of erroring. That caused dashboard Quick Add (which
+forces the light tier via `--fast`) to time out at 240 s with zero
+output. Updated to the actual current id `claude-haiku-4-5-20251001`
+(Haiku 4.5).

--- a/.changeset/haiku-model-id.md
+++ b/.changeset/haiku-model-id.md
@@ -7,5 +7,7 @@ Correct the haiku model id. `TIER_MODELS.claude.light` and
 exist — the API returns 404, but the Claude CLI provider hangs silently
 on the bad id instead of erroring. That caused dashboard Quick Add (which
 forces the light tier via `--fast`) to time out at 240 s with zero
-output. Updated to the actual current id `claude-haiku-4-5-20251001`
-(Haiku 4.5).
+output. Updated to the dateless alias `claude-haiku-4-5` (matching the
+existing pattern used for `opus`/`sonnet`); it resolves to the latest
+Haiku 4.5 release without pinning to a snapshot that will eventually be
+deprecated.

--- a/.changeset/prd-tree-row-cleanup.md
+++ b/.changeset/prd-tree-row-cleanup.md
@@ -1,0 +1,13 @@
+---
+"@n-dx/web": patch
+---
+
+PRD tree row decluttered. The Token Usage cell is now gated on the
+`showTokenBudget` feature flag (no more noisy column on every row when
+budgets aren't active). Duration and timestamp are removed from the
+row — both still live in the task detail flyout. The level badge
+(`EPIC` / `FEATURE` / `TASK` / `SUBTASK`) now renders only on the
+first item of each contiguous same-level group, so it reads as a
+section header for that indentation instead of repeating on every
+row. Status remains an icon-only indicator with the full label on
+hover.

--- a/.changeset/smart-add-nest-existing.md
+++ b/.changeset/smart-add-nest-existing.md
@@ -1,12 +1,27 @@
 ---
 "@n-dx/rex": patch
+"@n-dx/web": patch
 ---
 
-`n-dx add` no longer creates a duplicate epic when the work belongs under an
-existing one. Smart-add relied on the LLM setting `existingId` to nest under an
-existing epic/feature; when it didn't, a new epic with the same title was
-created. Added a deterministic post-generation placement pass that matches
-proposed epics/features against existing PRD containers (high-confidence,
-title-based) and fills `existingId` so the new task nests instead of
-duplicating. Respects an `existingId` the LLM already set; skipped when an
-explicit `--parent` is given.
+Smart-add fixes — nesting, dashboard Quick Add, and clearer errors.
+
+**Nesting (rex):** `n-dx add` no longer creates a duplicate epic when the work
+belongs under an existing one. The LLM was supposed to set `existingId` for
+placement under an existing epic/feature but often omitted it. Added a
+deterministic post-generation pass that matches proposed epics/features
+against existing PRD containers (high-confidence, title-based) and fills
+`existingId` so the new task nests instead of duplicating. Respects an
+`existingId` the LLM already set; skipped when an explicit `--parent` is
+given.
+
+**Dashboard Quick Add latency (rex + web):** new `--fast` flag for `rex add`
+forces the vendor's light tier (haiku for Claude, gpt-5.4-mini for Codex) so
+the CLI provider completes well within the timeout from a daemonized server.
+The web Quick Add preview now passes `--fast`; the user-driven CLI
+`n-dx add` is unchanged.
+
+**Timeout error message (web):** the smart-add timeout no longer wrongly
+implies "set an API key" is the fix — the Claude CLI provider is a valid
+first-class path. The message now points at the right diagnostic
+(`time claude -p`), notes an API key is only an optional speed-up, and
+appends captured stderr when present.

--- a/.changeset/smart-add-nest-existing.md
+++ b/.changeset/smart-add-nest-existing.md
@@ -1,0 +1,12 @@
+---
+"@n-dx/rex": patch
+---
+
+`n-dx add` no longer creates a duplicate epic when the work belongs under an
+existing one. Smart-add relied on the LLM setting `existingId` to nest under an
+existing epic/feature; when it didn't, a new epic with the same title was
+created. Added a deterministic post-generation placement pass that matches
+proposed epics/features against existing PRD containers (high-confidence,
+title-based) and fills `existingId` so the new task nests instead of
+duplicating. Respects an `existingId` the LLM already set; skipped when an
+explicit `--parent` is given.

--- a/packages/llm-client/src/cli-provider.ts
+++ b/packages/llm-client/src/cli-provider.ts
@@ -122,6 +122,10 @@ function spawnOnce(
     // nested inside an interactive Claude Code session (e.g. when the web
     // server is launched from within Claude Code).
     const { CLAUDECODE: _, ...cleanEnv } = process.env;
+    const spawnStart = Date.now();
+    process.stderr.write(
+      `[cli-provider] spawn claude ${cliBinary} model=${request.model} promptBytes=${request.prompt.length}\n`,
+    );
     const proc = spawn(cliBinary, args, {
       stdio: ["pipe", "pipe", "pipe"],
       shell: process.platform === "win32",
@@ -134,11 +138,31 @@ function spawnOnce(
     let stdout = "";
     let stderr = "";
 
+    // Per-call timeout — caps any single claude invocation so a stalled
+    // process surfaces as a clear, actionable error rather than 240s of
+    // silence (the outer foundationExec timeout).
+    const PER_CALL_TIMEOUT_MS = 90_000;
+    const killTimer = setTimeout(() => {
+      process.stderr.write(
+        `[cli-provider] claude hung past ${PER_CALL_TIMEOUT_MS / 1000}s — killing (stdout=${stdout.length}B, stderr=${stderr.length}B)\n`,
+      );
+      proc.kill("SIGTERM");
+      setTimeout(() => proc.kill("SIGKILL"), 2000).unref();
+    }, PER_CALL_TIMEOUT_MS);
+    killTimer.unref();
+
     proc.stdout.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
     });
     proc.stderr.on("data", (chunk: Buffer) => {
       stderr += chunk.toString();
+    });
+
+    proc.on("close", () => {
+      clearTimeout(killTimer);
+      process.stderr.write(
+        `[cli-provider] claude exited in ${Date.now() - spawnStart}ms (stdout=${stdout.length}B, stderr=${stderr.length}B)\n`,
+      );
     });
 
     proc.on("error", (err) => {

--- a/packages/llm-client/src/cli-provider.ts
+++ b/packages/llm-client/src/cli-provider.ts
@@ -102,6 +102,18 @@ function classifyStderr(stderr: string): { reason: "auth" | "rate-limit" | "unkn
   return { reason: "unknown", retryable: isTransientError(stderr) };
 }
 
+function isDebugEnabled(): boolean {
+  const v = process.env.NDX_DEBUG_LLM ?? process.env.NDX_DEBUG;
+  return v === "1" || v === "true" || v === "yes";
+}
+
+/** Per-call spawn tracing — opt-in via NDX_DEBUG_LLM / NDX_DEBUG. */
+function debugLog(message: string): void {
+  if (isDebugEnabled()) {
+    process.stderr.write(`[ndx:llm:claude] ${message}\n`);
+  }
+}
+
 /**
  * Spawn the Claude CLI once and collect the result.
  */
@@ -123,9 +135,7 @@ function spawnOnce(
     // server is launched from within Claude Code).
     const { CLAUDECODE: _, ...cleanEnv } = process.env;
     const spawnStart = Date.now();
-    process.stderr.write(
-      `[cli-provider] spawn claude ${cliBinary} model=${request.model} promptBytes=${request.prompt.length}\n`,
-    );
+    debugLog(`spawn ${cliBinary} model=${request.model} promptBytes=${request.prompt.length}`);
     const proc = spawn(cliBinary, args, {
       stdio: ["pipe", "pipe", "pipe"],
       shell: process.platform === "win32",
@@ -143,8 +153,10 @@ function spawnOnce(
     // silence (the outer foundationExec timeout).
     const PER_CALL_TIMEOUT_MS = 90_000;
     const killTimer = setTimeout(() => {
+      // Always log — a hung CLI being force-killed is an exceptional event,
+      // not per-call noise.
       process.stderr.write(
-        `[cli-provider] claude hung past ${PER_CALL_TIMEOUT_MS / 1000}s — killing (stdout=${stdout.length}B, stderr=${stderr.length}B)\n`,
+        `[ndx:llm:claude] claude hung past ${PER_CALL_TIMEOUT_MS / 1000}s — killing (stdout=${stdout.length}B, stderr=${stderr.length}B)\n`,
       );
       proc.kill("SIGTERM");
       setTimeout(() => proc.kill("SIGKILL"), 2000).unref();
@@ -160,9 +172,7 @@ function spawnOnce(
 
     proc.on("close", () => {
       clearTimeout(killTimer);
-      process.stderr.write(
-        `[cli-provider] claude exited in ${Date.now() - spawnStart}ms (stdout=${stdout.length}B, stderr=${stderr.length}B)\n`,
-      );
+      debugLog(`claude exited in ${Date.now() - spawnStart}ms (stdout=${stdout.length}B, stderr=${stderr.length}B)`);
     });
 
     proc.on("error", (err) => {

--- a/packages/llm-client/src/config.ts
+++ b/packages/llm-client/src/config.ts
@@ -48,7 +48,7 @@ export const NEWEST_MODELS: Record<LLMVendor, string> = {
  */
 export const TIER_MODELS: Record<LLMVendor, Record<TaskWeight, string>> = {
   claude: {
-    light: "claude-haiku-4-20250414",
+    light: "claude-haiku-4-5-20251001",
     standard: NEWEST_MODELS.claude,
   },
   codex: {
@@ -88,7 +88,7 @@ export const VENDOR_CONTEXT_CHAR_LIMITS: Record<LLMVendor, number> = {
 const MODEL_ALIASES: Record<string, string> = {
   sonnet: NEWEST_MODELS.claude,
   opus: "claude-opus-4-7",
-  haiku: "claude-haiku-4-20250414",
+  haiku: "claude-haiku-4-5-20251001",
 };
 
 /**

--- a/packages/llm-client/src/config.ts
+++ b/packages/llm-client/src/config.ts
@@ -48,7 +48,7 @@ export const NEWEST_MODELS: Record<LLMVendor, string> = {
  */
 export const TIER_MODELS: Record<LLMVendor, Record<TaskWeight, string>> = {
   claude: {
-    light: "claude-haiku-4-5-20251001",
+    light: "claude-haiku-4-5",
     standard: NEWEST_MODELS.claude,
   },
   codex: {
@@ -88,7 +88,7 @@ export const VENDOR_CONTEXT_CHAR_LIMITS: Record<LLMVendor, number> = {
 const MODEL_ALIASES: Record<string, string> = {
   sonnet: NEWEST_MODELS.claude,
   opus: "claude-opus-4-7",
-  haiku: "claude-haiku-4-5-20251001",
+  haiku: "claude-haiku-4-5",
 };
 
 /**

--- a/packages/llm-client/src/exec.ts
+++ b/packages/llm-client/src/exec.ts
@@ -76,7 +76,11 @@ export function exec(
   const { cwd, timeout, maxBuffer = DEFAULT_MAX_BUFFER, env } = opts;
 
   return new Promise((resolve) => {
-    execFile(cmd, args, { cwd, timeout, maxBuffer, env }, (error, stdout, stderr) => {
+    const child = execFile(cmd, args, { cwd, timeout, maxBuffer, env }, (
+      error,
+      stdout,
+      stderr,
+    ) => {
       const isTimeout = error
         ? (error as NodeJS.ErrnoException & { code?: number | string }).code === "ETIMEDOUT" ||
           (error as { killed?: boolean }).killed === true
@@ -96,6 +100,11 @@ export function exec(
         error: error as Error | null,
       });
     });
+    // Close the child's stdin immediately. `execFile` pipes stdio by default
+    // but the parent never writes anything — leaving stdin open makes any
+    // child that reads from stdin (e.g. `rex add` calling readStdin() in a
+    // non-TTY) hang forever waiting for an EOF that will never arrive.
+    child.stdin?.end();
   });
 }
 

--- a/packages/llm-client/tests/integration/weight-aware-model-resolution.test.ts
+++ b/packages/llm-client/tests/integration/weight-aware-model-resolution.test.ts
@@ -45,7 +45,7 @@ describe("weight-aware model resolution chain", () => {
       const config = await loadLLMConfig(tmpDir);
       const model = resolveVendorModel("claude", config, "light");
       expect(model).toBe(TIER_MODELS.claude.light);
-      expect(model).toBe("claude-haiku-4-20250414");
+      expect(model).toBe("claude-haiku-4-5-20251001");
     });
 
     it("returns codex light model when weight is light and no config", async () => {
@@ -61,13 +61,13 @@ describe("weight-aware model resolution chain", () => {
         JSON.stringify({
           llm: {
             vendor: "claude",
-            claude: { lightModel: "claude-haiku-4-20250414" },
+            claude: { lightModel: "claude-haiku-4-5-20251001" },
           },
         }),
       );
       const config = await loadLLMConfig(tmpDir);
       const model = resolveVendorModel("claude", config, "light");
-      expect(model).toBe("claude-haiku-4-20250414");
+      expect(model).toBe("claude-haiku-4-5-20251001");
     });
 
     it("uses lightModel from config when weight is light for codex", async () => {
@@ -155,7 +155,7 @@ describe("weight-aware model resolution chain", () => {
         JSON.stringify({
           llm: {
             vendor: "claude",
-            claude: { lightModel: "claude-haiku-4-20250414" },
+            claude: { lightModel: "claude-haiku-4-5-20251001" },
           },
         }),
       );
@@ -209,7 +209,7 @@ describe("weight-aware model resolution chain", () => {
 
     it("explicit model string overrides tier-based selection for standard weight", () => {
       // Simulates: CLI flag --model=haiku passed to a standard-tier command
-      const explicitModel = "claude-haiku-4-20250414";
+      const explicitModel = "claude-haiku-4-5-20251001";
       const config: LLMConfig = { claude: { model: "claude-opus-4-20250514" } };
       // When caller has explicit model, they use it directly
       expect(explicitModel).not.toBe(resolveVendorModel("claude", config, "standard"));
@@ -270,19 +270,19 @@ describe("weight-aware model resolution chain", () => {
           // Legacy format: claude at top level instead of under llm
           claude: {
             model: "claude-opus-4-20250514",
-            lightModel: "claude-haiku-4-20250414",
+            lightModel: "claude-haiku-4-5-20251001",
           },
         }),
       );
       const config = await loadLLMConfig(tmpDir);
       expect(config.claude?.model).toBe("claude-opus-4-20250514");
-      expect(config.claude?.lightModel).toBe("claude-haiku-4-20250414");
+      expect(config.claude?.lightModel).toBe("claude-haiku-4-5-20251001");
 
       const standardModel = resolveVendorModel("claude", config, "standard");
       expect(standardModel).toBe("claude-opus-4-20250514");
 
       const lightModel = resolveVendorModel("claude", config, "light");
-      expect(lightModel).toBe("claude-haiku-4-20250414");
+      expect(lightModel).toBe("claude-haiku-4-5-20251001");
     });
 
     it("llm.claude takes precedence over legacy top-level claude", async () => {

--- a/packages/llm-client/tests/integration/weight-aware-model-resolution.test.ts
+++ b/packages/llm-client/tests/integration/weight-aware-model-resolution.test.ts
@@ -45,7 +45,7 @@ describe("weight-aware model resolution chain", () => {
       const config = await loadLLMConfig(tmpDir);
       const model = resolveVendorModel("claude", config, "light");
       expect(model).toBe(TIER_MODELS.claude.light);
-      expect(model).toBe("claude-haiku-4-5-20251001");
+      expect(model).toBe("claude-haiku-4-5");
     });
 
     it("returns codex light model when weight is light and no config", async () => {
@@ -61,13 +61,13 @@ describe("weight-aware model resolution chain", () => {
         JSON.stringify({
           llm: {
             vendor: "claude",
-            claude: { lightModel: "claude-haiku-4-5-20251001" },
+            claude: { lightModel: "claude-haiku-4-5" },
           },
         }),
       );
       const config = await loadLLMConfig(tmpDir);
       const model = resolveVendorModel("claude", config, "light");
-      expect(model).toBe("claude-haiku-4-5-20251001");
+      expect(model).toBe("claude-haiku-4-5");
     });
 
     it("uses lightModel from config when weight is light for codex", async () => {
@@ -155,7 +155,7 @@ describe("weight-aware model resolution chain", () => {
         JSON.stringify({
           llm: {
             vendor: "claude",
-            claude: { lightModel: "claude-haiku-4-5-20251001" },
+            claude: { lightModel: "claude-haiku-4-5" },
           },
         }),
       );
@@ -209,7 +209,7 @@ describe("weight-aware model resolution chain", () => {
 
     it("explicit model string overrides tier-based selection for standard weight", () => {
       // Simulates: CLI flag --model=haiku passed to a standard-tier command
-      const explicitModel = "claude-haiku-4-5-20251001";
+      const explicitModel = "claude-haiku-4-5";
       const config: LLMConfig = { claude: { model: "claude-opus-4-20250514" } };
       // When caller has explicit model, they use it directly
       expect(explicitModel).not.toBe(resolveVendorModel("claude", config, "standard"));
@@ -270,19 +270,19 @@ describe("weight-aware model resolution chain", () => {
           // Legacy format: claude at top level instead of under llm
           claude: {
             model: "claude-opus-4-20250514",
-            lightModel: "claude-haiku-4-5-20251001",
+            lightModel: "claude-haiku-4-5",
           },
         }),
       );
       const config = await loadLLMConfig(tmpDir);
       expect(config.claude?.model).toBe("claude-opus-4-20250514");
-      expect(config.claude?.lightModel).toBe("claude-haiku-4-5-20251001");
+      expect(config.claude?.lightModel).toBe("claude-haiku-4-5");
 
       const standardModel = resolveVendorModel("claude", config, "standard");
       expect(standardModel).toBe("claude-opus-4-20250514");
 
       const lightModel = resolveVendorModel("claude", config, "light");
-      expect(lightModel).toBe("claude-haiku-4-5-20251001");
+      expect(lightModel).toBe("claude-haiku-4-5");
     });
 
     it("llm.claude takes precedence over legacy top-level claude", async () => {

--- a/packages/llm-client/tests/unit/config.test.ts
+++ b/packages/llm-client/tests/unit/config.test.ts
@@ -60,13 +60,13 @@ describe("loadClaudeConfig", () => {
       JSON.stringify({
         claude: {
           model: "claude-sonnet-4-6",
-          lightModel: "claude-haiku-4-20250414",
+          lightModel: "claude-haiku-4-5-20251001",
         },
       }),
     );
 
     const config = await loadClaudeConfig(tmpDir);
-    expect(config.lightModel).toBe("claude-haiku-4-20250414");
+    expect(config.lightModel).toBe("claude-haiku-4-5-20251001");
     expect(config.model).toBe("claude-sonnet-4-6");
   });
 
@@ -267,7 +267,7 @@ describe("TIER_MODELS", () => {
   });
 
   it("claude.light maps to haiku", () => {
-    expect(TIER_MODELS.claude.light).toBe("claude-haiku-4-20250414");
+    expect(TIER_MODELS.claude.light).toBe("claude-haiku-4-5-20251001");
   });
 
   it("codex.light maps to gpt-5.4-mini", () => {
@@ -367,15 +367,15 @@ describe("resolveVendorModel", () => {
     it("expands claude alias when using light tier", () => {
       // Light tier for Claude should not need alias expansion (it's a full model ID)
       // but verify the resolver path still works correctly
-      expect(resolveVendorModel("claude", {}, "light")).toBe("claude-haiku-4-20250414");
+      expect(resolveVendorModel("claude", {}, "light")).toBe("claude-haiku-4-5-20251001");
     });
   });
 
   // Per-tier config override tests (lightModel)
   describe("with lightModel config override", () => {
     it("uses lightModel for claude when weight is 'light' and lightModel is set", () => {
-      const config = { claude: { lightModel: "claude-haiku-4-20250414" } };
-      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-20250414");
+      const config = { claude: { lightModel: "claude-haiku-4-5-20251001" } };
+      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-5-20251001");
     });
 
     it("uses lightModel for codex when weight is 'light' and lightModel is set", () => {
@@ -392,7 +392,7 @@ describe("resolveVendorModel", () => {
     });
 
     it("lightModel is ignored when weight is 'standard' for claude", () => {
-      const config = { claude: { lightModel: "claude-haiku-4-20250414" } };
+      const config = { claude: { lightModel: "claude-haiku-4-5-20251001" } };
       expect(resolveVendorModel("claude", config, "standard")).toBe(NEWEST_MODELS.claude);
     });
 
@@ -403,7 +403,7 @@ describe("resolveVendorModel", () => {
 
     it("expands claude alias in lightModel config", () => {
       const config = { claude: { lightModel: "haiku" } };
-      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-20250414");
+      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-5-20251001");
     });
 
     it("lightModel takes precedence over TIER_MODELS.light for claude", () => {

--- a/packages/llm-client/tests/unit/config.test.ts
+++ b/packages/llm-client/tests/unit/config.test.ts
@@ -60,13 +60,13 @@ describe("loadClaudeConfig", () => {
       JSON.stringify({
         claude: {
           model: "claude-sonnet-4-6",
-          lightModel: "claude-haiku-4-5-20251001",
+          lightModel: "claude-haiku-4-5",
         },
       }),
     );
 
     const config = await loadClaudeConfig(tmpDir);
-    expect(config.lightModel).toBe("claude-haiku-4-5-20251001");
+    expect(config.lightModel).toBe("claude-haiku-4-5");
     expect(config.model).toBe("claude-sonnet-4-6");
   });
 
@@ -267,7 +267,7 @@ describe("TIER_MODELS", () => {
   });
 
   it("claude.light maps to haiku", () => {
-    expect(TIER_MODELS.claude.light).toBe("claude-haiku-4-5-20251001");
+    expect(TIER_MODELS.claude.light).toBe("claude-haiku-4-5");
   });
 
   it("codex.light maps to gpt-5.4-mini", () => {
@@ -367,15 +367,15 @@ describe("resolveVendorModel", () => {
     it("expands claude alias when using light tier", () => {
       // Light tier for Claude should not need alias expansion (it's a full model ID)
       // but verify the resolver path still works correctly
-      expect(resolveVendorModel("claude", {}, "light")).toBe("claude-haiku-4-5-20251001");
+      expect(resolveVendorModel("claude", {}, "light")).toBe("claude-haiku-4-5");
     });
   });
 
   // Per-tier config override tests (lightModel)
   describe("with lightModel config override", () => {
     it("uses lightModel for claude when weight is 'light' and lightModel is set", () => {
-      const config = { claude: { lightModel: "claude-haiku-4-5-20251001" } };
-      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-5-20251001");
+      const config = { claude: { lightModel: "claude-haiku-4-5" } };
+      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-5");
     });
 
     it("uses lightModel for codex when weight is 'light' and lightModel is set", () => {
@@ -392,7 +392,7 @@ describe("resolveVendorModel", () => {
     });
 
     it("lightModel is ignored when weight is 'standard' for claude", () => {
-      const config = { claude: { lightModel: "claude-haiku-4-5-20251001" } };
+      const config = { claude: { lightModel: "claude-haiku-4-5" } };
       expect(resolveVendorModel("claude", config, "standard")).toBe(NEWEST_MODELS.claude);
     });
 
@@ -403,7 +403,7 @@ describe("resolveVendorModel", () => {
 
     it("expands claude alias in lightModel config", () => {
       const config = { claude: { lightModel: "haiku" } };
-      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-5-20251001");
+      expect(resolveVendorModel("claude", config, "light")).toBe("claude-haiku-4-5");
     });
 
     it("lightModel takes precedence over TIER_MODELS.light for claude", () => {

--- a/packages/llm-client/tests/unit/llm-config.test.ts
+++ b/packages/llm-client/tests/unit/llm-config.test.ts
@@ -60,7 +60,7 @@ describe("loadLLMConfig", () => {
         llm: {
           claude: {
             model: "claude-sonnet-4-6",
-            lightModel: "claude-haiku-4-20250414",
+            lightModel: "claude-haiku-4-5-20251001",
           },
         },
       }, null, 2),
@@ -69,7 +69,7 @@ describe("loadLLMConfig", () => {
 
     const cfg = await loadLLMConfig(tmpDir);
     expect(cfg.claude?.model).toBe("claude-sonnet-4-6");
-    expect(cfg.claude?.lightModel).toBe("claude-haiku-4-20250414");
+    expect(cfg.claude?.lightModel).toBe("claude-haiku-4-5-20251001");
   });
 
   it("reads lightModel from llm.codex section", async () => {

--- a/packages/llm-client/tests/unit/llm-config.test.ts
+++ b/packages/llm-client/tests/unit/llm-config.test.ts
@@ -60,7 +60,7 @@ describe("loadLLMConfig", () => {
         llm: {
           claude: {
             model: "claude-sonnet-4-6",
-            lightModel: "claude-haiku-4-5-20251001",
+            lightModel: "claude-haiku-4-5",
           },
         },
       }, null, 2),
@@ -69,7 +69,7 @@ describe("loadLLMConfig", () => {
 
     const cfg = await loadLLMConfig(tmpDir);
     expect(cfg.claude?.model).toBe("claude-sonnet-4-6");
-    expect(cfg.claude?.lightModel).toBe("claude-haiku-4-5-20251001");
+    expect(cfg.claude?.lightModel).toBe("claude-haiku-4-5");
   });
 
   it("reads lightModel from llm.codex section", async () => {

--- a/packages/llm-client/tests/unit/vendor-failover.test.ts
+++ b/packages/llm-client/tests/unit/vendor-failover.test.ts
@@ -58,7 +58,7 @@ describe("getNextFailoverAttempt", () => {
     // Codex starts at gpt-5.5 (standard tier), failover chain is:
     // 1. gpt-5.4-mini (codex light)
     // 2. claude-sonnet-4-6 (claude standard)
-    // 3. claude-haiku-4-5-20251001 (claude light)
+    // 3. claude-haiku-4-5 (claude light)
     // 4+ exhausted
 
     it("returns codex light on first failover attempt", () => {

--- a/packages/llm-client/tests/unit/vendor-failover.test.ts
+++ b/packages/llm-client/tests/unit/vendor-failover.test.ts
@@ -58,7 +58,7 @@ describe("getNextFailoverAttempt", () => {
     // Codex starts at gpt-5.5 (standard tier), failover chain is:
     // 1. gpt-5.4-mini (codex light)
     // 2. claude-sonnet-4-6 (claude standard)
-    // 3. claude-haiku-4-20250414 (claude light)
+    // 3. claude-haiku-4-5-20251001 (claude light)
     // 4+ exhausted
 
     it("returns codex light on first failover attempt", () => {

--- a/packages/llm-client/tests/unit/vendor-header.test.ts
+++ b/packages/llm-client/tests/unit/vendor-header.test.ts
@@ -117,12 +117,12 @@ describe("printVendorModelHeader", () => {
     const config: LLMConfig = { vendor: "claude" };
     // lastModel is an older model — different from current NEWEST_MODELS.claude
     printVendorModelHeader("claude", config, {
-      lastModel: "claude-haiku-4-5-20251001",
+      lastModel: "claude-haiku-4-5",
     });
     expect(errorSpy).toHaveBeenCalledOnce();
     const warning = errorSpy.mock.calls[0][0] as string;
     expect(warning).toContain("model changed since last run");
-    expect(warning).toContain("claude-haiku-4-5-20251001");
+    expect(warning).toContain("claude-haiku-4-5");
     expect(warning).toContain(NEWEST_MODELS.claude);
   });
 
@@ -264,7 +264,7 @@ describe("printVendorModelHeader", () => {
     it("renders '(light tier, configured)' when tier is light and lightModel is configured", () => {
       const config: LLMConfig = {
         vendor: "claude",
-        claude: { lightModel: "claude-haiku-4-5-20251001" },
+        claude: { lightModel: "claude-haiku-4-5" },
       };
       printVendorModelHeader("claude", config, {
         resolvedModel: TIER_MODELS.claude.light,

--- a/packages/llm-client/tests/unit/vendor-header.test.ts
+++ b/packages/llm-client/tests/unit/vendor-header.test.ts
@@ -117,12 +117,12 @@ describe("printVendorModelHeader", () => {
     const config: LLMConfig = { vendor: "claude" };
     // lastModel is an older model — different from current NEWEST_MODELS.claude
     printVendorModelHeader("claude", config, {
-      lastModel: "claude-haiku-4-20250414",
+      lastModel: "claude-haiku-4-5-20251001",
     });
     expect(errorSpy).toHaveBeenCalledOnce();
     const warning = errorSpy.mock.calls[0][0] as string;
     expect(warning).toContain("model changed since last run");
-    expect(warning).toContain("claude-haiku-4-20250414");
+    expect(warning).toContain("claude-haiku-4-5-20251001");
     expect(warning).toContain(NEWEST_MODELS.claude);
   });
 
@@ -264,7 +264,7 @@ describe("printVendorModelHeader", () => {
     it("renders '(light tier, configured)' when tier is light and lightModel is configured", () => {
       const config: LLMConfig = {
         vendor: "claude",
-        claude: { lightModel: "claude-haiku-4-20250414" },
+        claude: { lightModel: "claude-haiku-4-5-20251001" },
       };
       printVendorModelHeader("claude", config, {
         resolvedModel: TIER_MODELS.claude.light,

--- a/packages/llm-client/tests/unit/vendor-model-reset.test.ts
+++ b/packages/llm-client/tests/unit/vendor-model-reset.test.ts
@@ -16,7 +16,7 @@ describe("vendor-model-reset", () => {
         expect(isModelCompatibleWithVendor("claude", "claude-opus-4-20250514")).toBe(
           true,
         );
-        expect(isModelCompatibleWithVendor("claude", "claude-haiku-4-20250414")).toBe(
+        expect(isModelCompatibleWithVendor("claude", "claude-haiku-4-5-20251001")).toBe(
           true,
         );
       });

--- a/packages/llm-client/tests/unit/vendor-model-reset.test.ts
+++ b/packages/llm-client/tests/unit/vendor-model-reset.test.ts
@@ -16,7 +16,7 @@ describe("vendor-model-reset", () => {
         expect(isModelCompatibleWithVendor("claude", "claude-opus-4-20250514")).toBe(
           true,
         );
-        expect(isModelCompatibleWithVendor("claude", "claude-haiku-4-5-20251001")).toBe(
+        expect(isModelCompatibleWithVendor("claude", "claude-haiku-4-5")).toBe(
           true,
         );
       });

--- a/packages/rex/src/cli/commands/smart-add-duplicates.ts
+++ b/packages/rex/src/cli/commands/smart-add-duplicates.ts
@@ -161,6 +161,9 @@ export function attachDuplicateReasonsToProposals(
         title: proposal.epic.title,
         source: proposal.epic.source,
         description: proposal.epic.description,
+        // Preserve existingId so smart-placement carries through to JSON
+        // output and the web accept handler can nest under the matched epic.
+        ...(proposal.epic.existingId ? { existingId: proposal.epic.existingId } : {}),
         ...(epicReason ? { duplicateReason: epicReason } : {}),
       },
       features: proposal.features.map((feature, fIdx) => {
@@ -171,6 +174,7 @@ export function attachDuplicateReasonsToProposals(
           title: feature.title,
           source: feature.source,
           description: feature.description,
+          ...(feature.existingId ? { existingId: feature.existingId } : {}),
           ...(featureReason ? { duplicateReason: featureReason } : {}),
           tasks: feature.tasks.map((task, tIdx) => {
             const taskKey = `p${pIdx}:task:${fIdx}:${tIdx}`;

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1793,7 +1793,12 @@ export async function cmdSmartAdd(
   const model = fast
     ? (await resolveLightSmartAddModel(dir)) ?? (await resolveSmartAddModel(dir, flags.model))
     : await resolveSmartAddModel(dir, flags.model);
+  process.stderr.write(
+    `[smart-add] fast=${fast} model=${model ?? "(default)"} isJson=${input.isJson} parentId=${input.parentId ?? "(none)"}\n`,
+  );
   const { existing, parentLevel, itemFileMap } = await loadSmartAddContext(dir, input.parentId);
+  const genStart = Date.now();
+  process.stderr.write(`[smart-add] generate: starting\n`);
   const proposals = await generateSmartAddProposals({
     dir,
     existing,
@@ -1803,6 +1808,7 @@ export async function cmdSmartAdd(
     filePaths: input.filePaths,
     isJson: input.isJson,
   });
+  process.stderr.write(`[smart-add] generate: done in ${Date.now() - genStart}ms, proposals=${proposals.length}\n`);
 
   if (proposals.length === 0) {
     emitNoSmartAddProposals(input.isJson);
@@ -1824,11 +1830,14 @@ export async function cmdSmartAdd(
   // Post-processing consolidation guard: reduce over-granular LLM output
   let consolidatedProposals = proposals;
   {
+    const guardStart = Date.now();
+    process.stderr.write(`[smart-add] consolidation guard: starting\n`);
     const guardResult = await applyConsolidationGuard(
       consolidatedProposals,
       loeConfig,
       model,
     );
+    process.stderr.write(`[smart-add] consolidation guard: done in ${Date.now() - guardStart}ms, triggered=${guardResult.triggered}\n`);
 
     if (guardResult.triggered) {
       consolidatedProposals = guardResult.proposals;

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1385,6 +1385,11 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
         );
         continue;
       }
+      // Only auto-match a feature when its epic is also being nested into an
+      // existing one — otherwise we'd attach the new feature's tasks under a
+      // feature that lives in a DIFFERENT existing epic, leaving the
+      // proposal's epic orphaned.
+      if (!p.epic.existingId) continue;
       const match = matchProposalNodeToPRD(
         { key: "feature", kind: "feature", title: feature.title, description: feature.description },
         existing,

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1307,30 +1307,27 @@ async function loadSmartAddContext(
   return { existing, parentLevel, itemFileMap };
 }
 
-/** A proposed container confidently maps to an existing epic/feature. */
-function isConfidentContainerMatch(
+/**
+ * A proposed container should reuse an existing one if the dedup scorer
+ * already considers them a match (`match.duplicate`). That scorer combines
+ * exact-title, semantic title-contains, and blended title+content similarity
+ * with a 0.7 threshold — already calibrated for "this is the same thing,"
+ * so trust it here rather than imposing an extra-strict 0.85 gate that
+ * silently dropped real content-overlap matches and let duplicates through.
+ */
+function isContainerMatch(
   match: ProposalDuplicateMatch,
   kind: "epic" | "feature",
 ): boolean {
-  if (!match.duplicate || !match.matchedItem || match.matchedItem.level !== kind) {
-    return false;
-  }
-  // Title-based matches are reliable; for blended matches require a high score
-  // so we never fold a genuinely new epic into an unrelated existing one.
-  return (
-    match.reason === "exact_title" ||
-    match.reason === "semantic_title" ||
-    match.score >= 0.85
-  );
+  return !!match.duplicate && !!match.matchedItem && match.matchedItem.level === kind;
 }
 
 /**
- * Auto-fill `existingId` on proposed epics/features that confidently match an
- * existing PRD container, so `n-dx add` nests the new task under the existing
- * epic/feature instead of creating a duplicate epic. The LLM is supposed to
- * set `existingId` itself but is unreliable; this is the deterministic
- * fallback. Conservative by design: respects an `existingId` the LLM already
- * set, and only acts on high-confidence container matches.
+ * Auto-fill `existingId` on proposed epics/features that match an existing
+ * PRD container, so `n-dx add` nests the new task under the existing
+ * epic/feature instead of creating a duplicate. The LLM is supposed to set
+ * `existingId` itself but is unreliable; this is the deterministic fallback.
+ * Respects an `existingId` the LLM already set.
  */
 export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]): void {
   if (existing.length === 0) return;
@@ -1340,8 +1337,12 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
         { key: "epic", kind: "epic", title: p.epic.title, description: p.epic.description },
         existing,
       );
-      if (isConfidentContainerMatch(match, "epic")) {
+      if (isContainerMatch(match, "epic")) {
         p.epic.existingId = match.matchedItem!.id;
+        process.stderr.write(
+          `[smart-add] place epic "${p.epic.title}" -> existing "${match.matchedItem!.title}" ` +
+            `(reason=${match.reason} score=${match.score.toFixed(2)})\n`,
+        );
       }
     }
     for (const feature of p.features) {
@@ -1350,8 +1351,12 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
         { key: "feature", kind: "feature", title: feature.title, description: feature.description },
         existing,
       );
-      if (isConfidentContainerMatch(match, "feature")) {
+      if (isContainerMatch(match, "feature")) {
         feature.existingId = match.matchedItem!.id;
+        process.stderr.write(
+          `[smart-add] place feature "${feature.title}" -> existing "${match.matchedItem!.title}" ` +
+            `(reason=${match.reason} score=${match.score.toFixed(2)})\n`,
+        );
       }
     }
   }

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1772,6 +1772,7 @@ export async function cmdSmartAdd(
   flags: Record<string, string>,
   multiFlags: Record<string, string[]> = {},
 ): Promise<void> {
+  process.stderr.write(`[smart-add] cmdSmartAdd entered dir=${dir} flags=${JSON.stringify(flags)}\n`);
   const input = parseSmartAddInput(descriptions, flags, multiFlags);
 
   if (!(await hasRexDir(dir))) {

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -37,6 +37,7 @@ import { loadClaudeConfig, loadLLMConfig } from "../../store/project-config.js";
 import { hashPRD } from "../../core/pending-cache.js";
 import {
   matchProposalNodesToPRD,
+  matchProposalNodeToPRD,
   attachDuplicateReasonsToProposals,
   buildDuplicateOverrideMarkerIndex,
 } from "./smart-add-duplicates.js";
@@ -1290,6 +1291,56 @@ async function loadSmartAddContext(
   return { existing, parentLevel, itemFileMap };
 }
 
+/** A proposed container confidently maps to an existing epic/feature. */
+function isConfidentContainerMatch(
+  match: ProposalDuplicateMatch,
+  kind: "epic" | "feature",
+): boolean {
+  if (!match.duplicate || !match.matchedItem || match.matchedItem.level !== kind) {
+    return false;
+  }
+  // Title-based matches are reliable; for blended matches require a high score
+  // so we never fold a genuinely new epic into an unrelated existing one.
+  return (
+    match.reason === "exact_title" ||
+    match.reason === "semantic_title" ||
+    match.score >= 0.85
+  );
+}
+
+/**
+ * Auto-fill `existingId` on proposed epics/features that confidently match an
+ * existing PRD container, so `n-dx add` nests the new task under the existing
+ * epic/feature instead of creating a duplicate epic. The LLM is supposed to
+ * set `existingId` itself but is unreliable; this is the deterministic
+ * fallback. Conservative by design: respects an `existingId` the LLM already
+ * set, and only acts on high-confidence container matches.
+ */
+export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]): void {
+  if (existing.length === 0) return;
+  for (const p of proposals) {
+    if (!p.epic.existingId) {
+      const match = matchProposalNodeToPRD(
+        { key: "epic", kind: "epic", title: p.epic.title, description: p.epic.description },
+        existing,
+      );
+      if (isConfidentContainerMatch(match, "epic")) {
+        p.epic.existingId = match.matchedItem!.id;
+      }
+    }
+    for (const feature of p.features) {
+      if (feature.existingId) continue;
+      const match = matchProposalNodeToPRD(
+        { key: "feature", kind: "feature", title: feature.title, description: feature.description },
+        existing,
+      );
+      if (isConfidentContainerMatch(match, "feature")) {
+        feature.existingId = match.matchedItem!.id;
+      }
+    }
+  }
+}
+
 async function generateSmartAddProposals(params: {
   dir: string;
   existing: PRDItem[];
@@ -1317,6 +1368,7 @@ async function generateSmartAddProposals(params: {
         parentId,
       });
       const proposals = reasonResult.proposals;
+      if (!parentId) applySmartPlacement(proposals, existing);
       const method = reasonResult.tokenUsage.calls > 0
         ? `via LLM (${effectiveModel})`
         : "from file structure";
@@ -1344,6 +1396,7 @@ async function generateSmartAddProposals(params: {
       parentId,
     });
     const proposals = reasonResult.proposals;
+    if (!parentId) applySmartPlacement(proposals, existing);
     spinner?.stop(proposals.length > 0 ? `Generated ${proposals.length} proposal(s).` : undefined);
     return proposals;
   } catch (err) {

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1347,42 +1347,34 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
     // that don't exist in the PRD. Validate against the real id set; if it
     // doesn't resolve, clear and run our scorer so a real match can take over.
     if (p.epic.existingId && !knownIds.has(p.epic.existingId)) {
-      process.stderr.write(
-        `[smart-add] epic "${p.epic.title}" had LLM-hallucinated existingId="${p.epic.existingId}" — discarded\n`,
-      );
+      llmDebug(`epic "${p.epic.title}" had LLM-hallucinated existingId="${p.epic.existingId}" — discarded`);
       p.epic.existingId = undefined;
     }
     if (p.epic.existingId) {
-      process.stderr.write(
-        `[smart-add] epic "${p.epic.title}" honoring LLM existingId="${p.epic.existingId}" (title="${idToTitle.get(p.epic.existingId) ?? "?"}")\n`,
-      );
+      llmDebug(`epic "${p.epic.title}" honoring LLM existingId="${p.epic.existingId}" (title="${idToTitle.get(p.epic.existingId) ?? "?"}")`);
     } else {
       const match = matchProposalNodeToPRD(
         { key: "epic", kind: "epic", title: p.epic.title, description: p.epic.description },
         existing,
       );
       const placed = isContainerMatch(match, "epic");
-      process.stderr.write(
-        `[smart-add] epic "${p.epic.title}" -> ${
+      llmDebug(
+        `epic "${p.epic.title}" -> ${
           match.matchedItem
             ? `best="${match.matchedItem.title}" reason=${match.reason} score=${match.score.toFixed(2)} placed=${placed}`
             : `(no candidate; ${existing.length} existing items considered)`
-        }\n`,
+        }`,
       );
       if (placed) p.epic.existingId = match.matchedItem!.id;
     }
 
     for (const feature of p.features) {
       if (feature.existingId && !knownIds.has(feature.existingId)) {
-        process.stderr.write(
-          `[smart-add] feature "${feature.title}" had LLM-hallucinated existingId="${feature.existingId}" — discarded\n`,
-        );
+        llmDebug(`feature "${feature.title}" had LLM-hallucinated existingId="${feature.existingId}" — discarded`);
         feature.existingId = undefined;
       }
       if (feature.existingId) {
-        process.stderr.write(
-          `[smart-add] feature "${feature.title}" honoring LLM existingId="${feature.existingId}"\n`,
-        );
+        llmDebug(`feature "${feature.title}" honoring LLM existingId="${feature.existingId}"`);
         continue;
       }
       // Only auto-match a feature when its epic is also being nested into an
@@ -1395,12 +1387,12 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
         existing,
       );
       const placed = isContainerMatch(match, "feature");
-      process.stderr.write(
-        `[smart-add] feature "${feature.title}" -> ${
+      llmDebug(
+        `feature "${feature.title}" -> ${
           match.matchedItem
             ? `best="${match.matchedItem.title}" reason=${match.reason} score=${match.score.toFixed(2)} placed=${placed}`
             : `(no candidate)`
-        }\n`,
+        }`,
       );
       if (placed) feature.existingId = match.matchedItem!.id;
     }

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1331,15 +1331,37 @@ function isContainerMatch(
  */
 export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]): void {
   if (existing.length === 0) return;
+  const knownIds = new Set<string>();
+  const idToTitle = new Map<string, string>();
+  const collect = (items: PRDItem[]): void => {
+    for (const it of items) {
+      knownIds.add(it.id);
+      idToTitle.set(it.id, it.title);
+      if (it.children?.length) collect(it.children);
+    }
+  };
+  collect(existing);
+
   for (const p of proposals) {
-    if (!p.epic.existingId) {
+    // The LLM may set existingId itself — but it routinely hallucinates IDs
+    // that don't exist in the PRD. Validate against the real id set; if it
+    // doesn't resolve, clear and run our scorer so a real match can take over.
+    if (p.epic.existingId && !knownIds.has(p.epic.existingId)) {
+      process.stderr.write(
+        `[smart-add] epic "${p.epic.title}" had LLM-hallucinated existingId="${p.epic.existingId}" — discarded\n`,
+      );
+      p.epic.existingId = undefined;
+    }
+    if (p.epic.existingId) {
+      process.stderr.write(
+        `[smart-add] epic "${p.epic.title}" honoring LLM existingId="${p.epic.existingId}" (title="${idToTitle.get(p.epic.existingId) ?? "?"}")\n`,
+      );
+    } else {
       const match = matchProposalNodeToPRD(
         { key: "epic", kind: "epic", title: p.epic.title, description: p.epic.description },
         existing,
       );
       const placed = isContainerMatch(match, "epic");
-      // Log every epic considered + its best candidate so misses are visible
-      // (and we can tune the threshold against real proposals).
       process.stderr.write(
         `[smart-add] epic "${p.epic.title}" -> ${
           match.matchedItem
@@ -1347,12 +1369,22 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
             : `(no candidate; ${existing.length} existing items considered)`
         }\n`,
       );
-      if (placed) {
-        p.epic.existingId = match.matchedItem!.id;
-      }
+      if (placed) p.epic.existingId = match.matchedItem!.id;
     }
+
     for (const feature of p.features) {
-      if (feature.existingId) continue;
+      if (feature.existingId && !knownIds.has(feature.existingId)) {
+        process.stderr.write(
+          `[smart-add] feature "${feature.title}" had LLM-hallucinated existingId="${feature.existingId}" — discarded\n`,
+        );
+        feature.existingId = undefined;
+      }
+      if (feature.existingId) {
+        process.stderr.write(
+          `[smart-add] feature "${feature.title}" honoring LLM existingId="${feature.existingId}"\n`,
+        );
+        continue;
+      }
       const match = matchProposalNodeToPRD(
         { key: "feature", kind: "feature", title: feature.title, description: feature.description },
         existing,
@@ -1365,9 +1397,7 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
             : `(no candidate)`
         }\n`,
       );
-      if (placed) {
-        feature.existingId = match.matchedItem!.id;
-      }
+      if (placed) feature.existingId = match.matchedItem!.id;
     }
   }
 }

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1337,12 +1337,18 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
         { key: "epic", kind: "epic", title: p.epic.title, description: p.epic.description },
         existing,
       );
-      if (isContainerMatch(match, "epic")) {
+      const placed = isContainerMatch(match, "epic");
+      // Log every epic considered + its best candidate so misses are visible
+      // (and we can tune the threshold against real proposals).
+      process.stderr.write(
+        `[smart-add] epic "${p.epic.title}" -> ${
+          match.matchedItem
+            ? `best="${match.matchedItem.title}" reason=${match.reason} score=${match.score.toFixed(2)} placed=${placed}`
+            : `(no candidate; ${existing.length} existing items considered)`
+        }\n`,
+      );
+      if (placed) {
         p.epic.existingId = match.matchedItem!.id;
-        process.stderr.write(
-          `[smart-add] place epic "${p.epic.title}" -> existing "${match.matchedItem!.title}" ` +
-            `(reason=${match.reason} score=${match.score.toFixed(2)})\n`,
-        );
       }
     }
     for (const feature of p.features) {
@@ -1351,12 +1357,16 @@ export function applySmartPlacement(proposals: Proposal[], existing: PRDItem[]):
         { key: "feature", kind: "feature", title: feature.title, description: feature.description },
         existing,
       );
-      if (isContainerMatch(match, "feature")) {
+      const placed = isContainerMatch(match, "feature");
+      process.stderr.write(
+        `[smart-add] feature "${feature.title}" -> ${
+          match.matchedItem
+            ? `best="${match.matchedItem.title}" reason=${match.reason} score=${match.score.toFixed(2)} placed=${placed}`
+            : `(no candidate)`
+        }\n`,
+      );
+      if (placed) {
         feature.existingId = match.matchedItem!.id;
-        process.stderr.write(
-          `[smart-add] place feature "${feature.title}" -> existing "${match.matchedItem!.title}" ` +
-            `(reason=${match.reason} score=${match.score.toFixed(2)})\n`,
-        );
       }
     }
   }

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1822,7 +1822,6 @@ export async function cmdSmartAdd(
   flags: Record<string, string>,
   multiFlags: Record<string, string[]> = {},
 ): Promise<void> {
-  process.stderr.write(`[smart-add] cmdSmartAdd entered dir=${dir} flags=${JSON.stringify(flags)}\n`);
   const input = parseSmartAddInput(descriptions, flags, multiFlags);
 
   if (!(await hasRexDir(dir))) {
@@ -1844,12 +1843,7 @@ export async function cmdSmartAdd(
   const model = fast
     ? (await resolveLightSmartAddModel(dir)) ?? (await resolveSmartAddModel(dir, flags.model))
     : await resolveSmartAddModel(dir, flags.model);
-  process.stderr.write(
-    `[smart-add] fast=${fast} model=${model ?? "(default)"} isJson=${input.isJson} parentId=${input.parentId ?? "(none)"}\n`,
-  );
   const { existing, parentLevel, itemFileMap } = await loadSmartAddContext(dir, input.parentId);
-  const genStart = Date.now();
-  process.stderr.write(`[smart-add] generate: starting\n`);
   const proposals = await generateSmartAddProposals({
     dir,
     existing,
@@ -1859,7 +1853,6 @@ export async function cmdSmartAdd(
     filePaths: input.filePaths,
     isJson: input.isJson,
   });
-  process.stderr.write(`[smart-add] generate: done in ${Date.now() - genStart}ms, proposals=${proposals.length}\n`);
 
   if (proposals.length === 0) {
     emitNoSmartAddProposals(input.isJson);
@@ -1881,14 +1874,11 @@ export async function cmdSmartAdd(
   // Post-processing consolidation guard: reduce over-granular LLM output
   let consolidatedProposals = proposals;
   {
-    const guardStart = Date.now();
-    process.stderr.write(`[smart-add] consolidation guard: starting\n`);
     const guardResult = await applyConsolidationGuard(
       consolidatedProposals,
       loeConfig,
       model,
     );
-    process.stderr.write(`[smart-add] consolidation guard: done in ${Date.now() - guardStart}ms, triggered=${guardResult.triggered}\n`);
 
     if (guardResult.triggered) {
       consolidatedProposals = guardResult.proposals;

--- a/packages/rex/src/cli/commands/smart-add.ts
+++ b/packages/rex/src/cli/commands/smart-add.ts
@@ -1220,6 +1220,22 @@ function emitPrdPaths(prdPaths: string[]): void {
   }
 }
 
+/**
+ * Resolve the vendor's light/fast tier model (haiku for claude,
+ * gpt-5.4-mini for codex) for `--fast`/preview smart-add runs where
+ * generation latency matters more than top-tier proposal quality.
+ */
+async function resolveLightSmartAddModel(dir: string): Promise<string | undefined> {
+  try {
+    const rexDir = join(dir, REX_DIR);
+    const llmConfig = await loadLLMConfig(rexDir);
+    const vendor = llmConfig.vendor ?? getLLMVendor() ?? "claude";
+    return resolveVendorModel(vendor, llmConfig, "light");
+  } catch {
+    return undefined;
+  }
+}
+
 async function resolveSmartAddModel(
   dir: string,
   requestedModel?: string,
@@ -1770,7 +1786,13 @@ export async function cmdSmartAdd(
     return;
   }
 
-  const model = await resolveSmartAddModel(dir, flags.model);
+  // `--fast` forces the light tier (e.g. haiku) — used by the web Quick Add
+  // preview where generation latency matters far more than top-tier quality.
+  // Explicit `--model` always wins.
+  const fast = flags.fast === "true" && !flags.model;
+  const model = fast
+    ? (await resolveLightSmartAddModel(dir)) ?? (await resolveSmartAddModel(dir, flags.model))
+    : await resolveSmartAddModel(dir, flags.model);
   const { existing, parentLevel, itemFileMap } = await loadSmartAddContext(dir, input.parentId);
   const proposals = await generateSmartAddProposals({
     dir,

--- a/packages/rex/src/cli/index.ts
+++ b/packages/rex/src/cli/index.ts
@@ -12,6 +12,10 @@ import { join } from "node:path";
 
 suppressKnownDeprecations();
 
+if (process.env.NDX_TRACE_SPAWN || process.argv.includes("add")) {
+  process.stderr.write(`[rex] cli/index.js loaded argv=${JSON.stringify(process.argv.slice(2))}\n`);
+}
+
 /** Post-write health warning — lazy-loaded to avoid startup cost. */
 async function postWriteHealthWarning(dir: string, isJson: boolean): Promise<void> {
   try {

--- a/packages/rex/src/cli/index.ts
+++ b/packages/rex/src/cli/index.ts
@@ -12,10 +12,6 @@ import { join } from "node:path";
 
 suppressKnownDeprecations();
 
-if (process.env.NDX_TRACE_SPAWN || process.argv.includes("add")) {
-  process.stderr.write(`[rex] cli/index.js loaded argv=${JSON.stringify(process.argv.slice(2))}\n`);
-}
-
 /** Post-write health warning — lazy-loaded to avoid startup cost. */
 async function postWriteHealthWarning(dir: string, isJson: boolean): Promise<void> {
   try {
@@ -177,10 +173,7 @@ async function dispatchAdd(
         'Usage: rex add <level> --title="..." or rex add "<description>" ["<desc2>" ...] or rex add --file=ideas.txt or echo "desc" | rex add',
       );
     }
-    process.stderr.write(`[rex] importing smart-add.js…\n`);
-    const importStart = Date.now();
     const { cmdSmartAdd } = await import("./commands/smart-add.js");
-    process.stderr.write(`[rex] smart-add.js imported in ${Date.now() - importStart}ms\n`);
     await cmdSmartAdd(dir, descriptions, flags, multiFlags);
     return;
   }

--- a/packages/rex/src/cli/index.ts
+++ b/packages/rex/src/cli/index.ts
@@ -177,7 +177,10 @@ async function dispatchAdd(
         'Usage: rex add <level> --title="..." or rex add "<description>" ["<desc2>" ...] or rex add --file=ideas.txt or echo "desc" | rex add',
       );
     }
+    process.stderr.write(`[rex] importing smart-add.js…\n`);
+    const importStart = Date.now();
     const { cmdSmartAdd } = await import("./commands/smart-add.js");
+    process.stderr.write(`[rex] smart-add.js imported in ${Date.now() - importStart}ms\n`);
     await cmdSmartAdd(dir, descriptions, flags, multiFlags);
     return;
   }

--- a/packages/rex/tests/unit/cli/commands/smart-add.test.ts
+++ b/packages/rex/tests/unit/cli/commands/smart-add.test.ts
@@ -734,16 +734,30 @@ describe("applySmartPlacement", () => {
     expect(proposals[0].features[0].existingId).toBeUndefined();
   });
 
-  it("respects an existingId the LLM already set", () => {
+  it("respects a valid existingId the LLM already set", () => {
     const proposals: Proposal[] = [
       {
-        epic: { title: "User Authentication", source: "smart-add", existingId: "epic-llm-chosen" },
+        epic: { title: "User Authentication", source: "smart-add", existingId: "epic-auth" },
         features: [],
       },
     ];
 
     applySmartPlacement(proposals, existing);
 
-    expect(proposals[0].epic.existingId).toBe("epic-llm-chosen");
+    expect(proposals[0].epic.existingId).toBe("epic-auth");
+  });
+
+  it("discards an LLM-hallucinated existingId that doesn't exist in the PRD", () => {
+    const proposals: Proposal[] = [
+      {
+        epic: { title: "User Authentication", source: "smart-add", existingId: "epic-hallucinated" },
+        features: [],
+      },
+    ];
+
+    applySmartPlacement(proposals, existing);
+
+    // Hallucinated id discarded; matcher then finds the real "User Authentication" epic by exact title.
+    expect(proposals[0].epic.existingId).toBe("epic-auth");
   });
 });

--- a/packages/rex/tests/unit/cli/commands/smart-add.test.ts
+++ b/packages/rex/tests/unit/cli/commands/smart-add.test.ts
@@ -10,9 +10,11 @@ import {
   remapDuplicateMatchesForSelectedProposals,
   formatQualityWarnings,
   classifySmartAddError,
+  applySmartPlacement,
 } from "../../../../src/cli/commands/smart-add.js";
 import type { Proposal, QualityIssue } from "../../../../src/analyze/index.js";
 import type { ProposalDuplicateMatch } from "../../../../src/cli/commands/smart-add-duplicates.js";
+import type { PRDItem } from "../../../../src/schema/index.js";
 
 const singleProposal: Proposal = {
   epic: { title: "User Authentication", source: "smart-add" },
@@ -670,5 +672,78 @@ describe("classifySmartAddError", () => {
 
     const r2 = classifySmartAddError(new Error("unauthorized request: check credentials"), "description");
     expect(r2.message).toContain("Authentication failed");
+  });
+});
+
+describe("applySmartPlacement", () => {
+  const existing: PRDItem[] = [
+    {
+      id: "epic-auth",
+      title: "User Authentication",
+      level: "epic",
+      status: "in_progress",
+      children: [
+        {
+          id: "feature-oauth",
+          title: "OAuth Integration",
+          level: "feature",
+          status: "pending",
+          children: [],
+        },
+      ],
+    },
+  ];
+
+  it("nests under an existing epic instead of creating a duplicate", () => {
+    const proposals: Proposal[] = [
+      {
+        epic: { title: "User Authentication", source: "smart-add" },
+        features: [
+          {
+            title: "OAuth Integration",
+            source: "smart-add",
+            tasks: [{ title: "Add Apple sign-in", source: "smart-add", sourceFile: "" }],
+          },
+        ],
+      },
+    ];
+
+    applySmartPlacement(proposals, existing);
+
+    expect(proposals[0].epic.existingId).toBe("epic-auth");
+    expect(proposals[0].features[0].existingId).toBe("feature-oauth");
+  });
+
+  it("does not touch a genuinely new epic", () => {
+    const proposals: Proposal[] = [
+      {
+        epic: { title: "Billing & Invoicing", source: "smart-add" },
+        features: [
+          {
+            title: "Stripe webhooks",
+            source: "smart-add",
+            tasks: [{ title: "Handle invoice.paid", source: "smart-add", sourceFile: "" }],
+          },
+        ],
+      },
+    ];
+
+    applySmartPlacement(proposals, existing);
+
+    expect(proposals[0].epic.existingId).toBeUndefined();
+    expect(proposals[0].features[0].existingId).toBeUndefined();
+  });
+
+  it("respects an existingId the LLM already set", () => {
+    const proposals: Proposal[] = [
+      {
+        epic: { title: "User Authentication", source: "smart-add", existingId: "epic-llm-chosen" },
+        features: [],
+      },
+    ];
+
+    applySmartPlacement(proposals, existing);
+
+    expect(proposals[0].epic.existingId).toBe("epic-llm-chosen");
   });
 });

--- a/packages/web/src/server/prd-io.ts
+++ b/packages/web/src/server/prd-io.ts
@@ -179,6 +179,23 @@ export function prdPath(rexDir: string): string {
 }
 
 /**
+ * Refresh ONLY the ephemeral cache (`.rex/.cache/prd.json`) — does NOT write
+ * `prd.md`. Use this when something has already written to the authoritative
+ * folder tree (`.rex/prd_tree/`) and we want the in-process `loadPRDSync`
+ * fast path to see the change immediately, without waiting for the
+ * folder-tree watcher.
+ */
+export function refreshPRDCache(rexDir: string, doc: PRDDocument): void {
+  try {
+    const cacheDir = join(rexDir, PRD_CACHE_DIR);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, PRD_CACHE_JSON), JSON.stringify(doc, null, 2) + "\n", "utf-8");
+  } catch {
+    // Cache write failure is non-fatal — the watcher will refresh it eventually.
+  }
+}
+
+/**
  * Return the latest modification time across `prd.md` and companion files (ms).
  * Returns 0 if no PRD files exist. Used by the data watcher for live-reload polling.
  */

--- a/packages/web/src/server/rex-gateway.ts
+++ b/packages/web/src/server/rex-gateway.ts
@@ -28,7 +28,7 @@ export { ensureLegacyPrdMigrated } from "@n-dx/rex";
 export type { LegacyPrdMigrationResult } from "@n-dx/rex";
 
 // ---- Rex folder-tree storage path -------------------------------------------
-export { PRD_TREE_DIRNAME, resolveStore } from "@n-dx/rex";
+export { PRD_TREE_DIRNAME, resolveStore, cascadeParentReset } from "@n-dx/rex";
 export type { PRDStore } from "@n-dx/rex";
 
 // ---- Rex schema version contract --------------------------------------------

--- a/packages/web/src/server/rex-gateway.ts
+++ b/packages/web/src/server/rex-gateway.ts
@@ -28,7 +28,8 @@ export { ensureLegacyPrdMigrated } from "@n-dx/rex";
 export type { LegacyPrdMigrationResult } from "@n-dx/rex";
 
 // ---- Rex folder-tree storage path -------------------------------------------
-export { PRD_TREE_DIRNAME } from "@n-dx/rex";
+export { PRD_TREE_DIRNAME, resolveStore } from "@n-dx/rex";
+export type { PRDStore } from "@n-dx/rex";
 
 // ---- Rex schema version contract --------------------------------------------
 export { SCHEMA_VERSION, isCompatibleSchema } from "@n-dx/rex";

--- a/packages/web/src/server/routes-rex-analysis.ts
+++ b/packages/web/src/server/routes-rex-analysis.ts
@@ -15,11 +15,13 @@ import { exec as foundationExec } from "@n-dx/llm-client";
 import type { ServerContext } from "./types.js";
 import { jsonResponse, errorResponse, readBody } from "./response-utils.js";
 import type { WebSocketBroadcaster } from "./websocket.js";
-import { insertChild, loadPRD, savePRD, appendLog } from "./routes-rex/rex-route-helpers.js";
+import { loadPRD, appendLog } from "./routes-rex/rex-route-helpers.js";
+import { refreshPRDCache } from "./prd-io.js";
 
 import {
   type PRDItem,
   isPriority,
+  resolveStore,
 } from "./rex-gateway.js";
 
 /**
@@ -335,6 +337,10 @@ async function handleAcceptProposals(
       return true;
     }
 
+    // See handleAcceptEditedProposals: write through the rex store so items
+    // land in the folder tree (the authoritative source per CLAUDE.md), not
+    // the legacy prd.md that the watcher overwrites.
+    const store = await resolveStore(ctx.rexDir);
     let addedCount = 0;
 
     for (const p of toAccept) {
@@ -347,7 +353,7 @@ async function handleAcceptProposals(
         source: p.epic.source,
       };
       if (p.epic.description) epicItem.description = p.epic.description;
-      doc.items.push(epicItem);
+      await store.addItem(epicItem);
       addedCount++;
 
       for (const f of p.features) {
@@ -360,7 +366,7 @@ async function handleAcceptProposals(
           source: f.source,
         };
         if (f.description) featureItem.description = f.description;
-        insertChild(doc.items, epicId, featureItem);
+        await store.addItem(featureItem, epicId);
         addedCount++;
 
         for (const t of f.tasks) {
@@ -376,13 +382,15 @@ async function handleAcceptProposals(
           if (t.acceptanceCriteria) taskItem.acceptanceCriteria = t.acceptanceCriteria;
           if (t.priority && isPriority(t.priority)) taskItem.priority = t.priority;
           if (t.tags) taskItem.tags = t.tags;
-          insertChild(doc.items, featureId, taskItem);
+          await store.addItem(taskItem, featureId);
           addedCount++;
         }
       }
     }
 
-    savePRD(ctx, doc);
+    // Refresh the cache from the store so the dashboard sees the new items
+    // immediately (see handleAcceptEditedProposals for context).
+    refreshPRDCache(ctx.rexDir, await store.loadDocument());
 
     // Remove accepted proposals from pending (keep remaining)
     if (input.indices && input.indices.length < allProposals.length) {
@@ -454,6 +462,12 @@ async function handleAcceptEditedProposals(
       return true;
     }
 
+    // Write through the rex store so items land in the folder tree
+    // (.rex/prd_tree/), the authoritative source per CLAUDE.md. The legacy
+    // savePRD/insertChild path only updated prd.md + the ephemeral cache —
+    // the folder-tree watcher then refreshed the cache from the unchanged
+    // tree, so accepted items appeared to vanish.
+    const store = await resolveStore(ctx.rexDir);
     let addedCount = 0;
     const selectedProposals = input.proposals.filter((p) => p.selected);
 
@@ -467,7 +481,7 @@ async function handleAcceptEditedProposals(
         source: "web-proposal-editor",
       };
       if (p.epic.description?.trim()) epicItem.description = p.epic.description.trim();
-      doc.items.push(epicItem);
+      await store.addItem(epicItem);
       addedCount++;
 
       for (const f of p.features) {
@@ -481,7 +495,7 @@ async function handleAcceptEditedProposals(
           source: "web-proposal-editor",
         };
         if (f.description?.trim()) featureItem.description = f.description.trim();
-        insertChild(doc.items, epicId, featureItem);
+        await store.addItem(featureItem, epicId);
         addedCount++;
 
         for (const t of f.tasks) {
@@ -498,7 +512,7 @@ async function handleAcceptEditedProposals(
           if (t.acceptanceCriteria?.length) taskItem.acceptanceCriteria = t.acceptanceCriteria;
           if (t.priority && isPriority(t.priority)) taskItem.priority = t.priority;
           if (t.tags?.length) taskItem.tags = t.tags;
-          insertChild(doc.items, featureId, taskItem);
+          await store.addItem(taskItem, featureId);
           addedCount++;
         }
       }
@@ -509,7 +523,10 @@ async function handleAcceptEditedProposals(
       return true;
     }
 
-    savePRD(ctx, doc);
+    // Refresh the cache from the store so the next GET /api/rex/prd in the
+    // same tick sees the new items (the folder-tree watcher would catch up
+    // eventually, but we want immediate visibility for the dashboard).
+    refreshPRDCache(ctx.rexDir, await store.loadDocument());
 
     // Clear pending proposals file
     const pendingPath = join(ctx.rexDir, "pending-proposals.json");

--- a/packages/web/src/server/routes-rex-analysis.ts
+++ b/packages/web/src/server/routes-rex-analysis.ts
@@ -22,6 +22,7 @@ import {
   type PRDItem,
   isPriority,
   resolveStore,
+  collectAllIds,
 } from "./rex-gateway.js";
 
 /**
@@ -76,12 +77,14 @@ interface EditedProposalTask {
 interface EditedProposalFeature {
   title: string;
   description?: string;
+  /** If set, nest tasks under this existing feature instead of creating a new one. */
+  existingId?: string;
   tasks: EditedProposalTask[];
   selected: boolean;
 }
 
 interface EditedProposal {
-  epic: { title: string; description?: string };
+  epic: { title: string; description?: string; existingId?: string };
   features: EditedProposalFeature[];
   selected: boolean;
 }
@@ -463,40 +466,52 @@ async function handleAcceptEditedProposals(
     }
 
     // Write through the rex store so items land in the folder tree
-    // (.rex/prd_tree/), the authoritative source per CLAUDE.md. The legacy
-    // savePRD/insertChild path only updated prd.md + the ephemeral cache —
-    // the folder-tree watcher then refreshed the cache from the unchanged
-    // tree, so accepted items appeared to vanish.
+    // (.rex/prd_tree/), the authoritative source per CLAUDE.md. Respect
+    // `existingId` on epic/feature so smart-placement nests under the
+    // matched container instead of creating a duplicate.
     const store = await resolveStore(ctx.rexDir);
+    const knownIds = new Set(collectAllIds((await store.loadDocument()).items));
     let addedCount = 0;
     const selectedProposals = input.proposals.filter((p) => p.selected);
 
     for (const p of selectedProposals) {
-      const epicId = randomUUID();
-      const epicItem: PRDItem = {
-        id: epicId,
-        title: p.epic.title.trim(),
-        level: "epic",
-        status: "pending",
-        source: "web-proposal-editor",
-      };
-      if (p.epic.description?.trim()) epicItem.description = p.epic.description.trim();
-      await store.addItem(epicItem);
-      addedCount++;
-
-      for (const f of p.features) {
-        if (!f.selected) continue;
-        const featureId = randomUUID();
-        const featureItem: PRDItem = {
-          id: featureId,
-          title: f.title.trim(),
-          level: "feature",
+      let epicId: string;
+      if (p.epic.existingId && knownIds.has(p.epic.existingId)) {
+        epicId = p.epic.existingId;
+      } else {
+        epicId = randomUUID();
+        const epicItem: PRDItem = {
+          id: epicId,
+          title: p.epic.title.trim(),
+          level: "epic",
           status: "pending",
           source: "web-proposal-editor",
         };
-        if (f.description?.trim()) featureItem.description = f.description.trim();
-        await store.addItem(featureItem, epicId);
+        if (p.epic.description?.trim()) epicItem.description = p.epic.description.trim();
+        await store.addItem(epicItem);
+        knownIds.add(epicId);
         addedCount++;
+      }
+
+      for (const f of p.features) {
+        if (!f.selected) continue;
+        let featureId: string;
+        if (f.existingId && knownIds.has(f.existingId)) {
+          featureId = f.existingId;
+        } else {
+          featureId = randomUUID();
+          const featureItem: PRDItem = {
+            id: featureId,
+            title: f.title.trim(),
+            level: "feature",
+            status: "pending",
+            source: "web-proposal-editor",
+          };
+          if (f.description?.trim()) featureItem.description = f.description.trim();
+          await store.addItem(featureItem, epicId);
+          knownIds.add(featureId);
+          addedCount++;
+        }
 
         for (const t of f.tasks) {
           if (!t.selected) continue;
@@ -513,6 +528,7 @@ async function handleAcceptEditedProposals(
           if (t.priority && isPriority(t.priority)) taskItem.priority = t.priority;
           if (t.tags?.length) taskItem.tags = t.tags;
           await store.addItem(taskItem, featureId);
+          knownIds.add(taskId);
           addedCount++;
         }
       }

--- a/packages/web/src/server/routes-rex-analysis.ts
+++ b/packages/web/src/server/routes-rex-analysis.ts
@@ -23,6 +23,7 @@ import {
   isPriority,
   resolveStore,
   collectAllIds,
+  cascadeParentReset,
 } from "./rex-gateway.js";
 
 /**
@@ -471,6 +472,10 @@ async function handleAcceptEditedProposals(
     // matched container instead of creating a duplicate.
     const store = await resolveStore(ctx.rexDir);
     const knownIds = new Set(collectAllIds((await store.loadDocument()).items));
+    // Parents whose status may need reverting from `completed` to `pending`
+    // after we nest a new task underneath them. Deduped so we only cascade
+    // each branch once at the end.
+    const parentsToCascade = new Set<string>();
     let addedCount = 0;
     const selectedProposals = input.proposals.filter((p) => p.selected);
 
@@ -538,8 +543,18 @@ async function handleAcceptEditedProposals(
           if (t.tags?.length) taskItem.tags = t.tags;
           await store.addItem(taskItem, featureId);
           knownIds.add(taskId);
+          parentsToCascade.add(featureId);
           addedCount++;
         }
+      }
+    }
+
+    // Reset any completed feature/epic in the chain back to `pending` now
+    // that they have a new in-progress task underneath them.
+    for (const parentId of parentsToCascade) {
+      const { resetItems } = await cascadeParentReset(store, parentId);
+      for (const item of resetItems) {
+        console.log(`[accept-edited] reset ${item.level} id=${item.id} title="${item.title}" -> pending`);
       }
     }
 

--- a/packages/web/src/server/routes-rex-analysis.ts
+++ b/packages/web/src/server/routes-rex-analysis.ts
@@ -573,10 +573,10 @@ async function handleSmartAddPreview(
     const binArgs = [...prefixArgs, ...args];
 
     // Smart add does a full LLM round-trip to generate a proposal tree.
-    // With an API key (ANTHROPIC_API_KEY / `n-dx config claude.api_key`) this
-    // takes seconds via the API provider. Without one, llm-client falls back
-    // to spawning the `claude` CLI, which is far slower from a long-running
-    // server process (no warm session) and can blow past the timeout.
+    // The Claude CLI provider (no API key needed) normally returns in well
+    // under a minute; a timeout here means the spawned `claude` process
+    // itself stalled in the server context (e.g. token refresh with no TTY,
+    // or a different PATH/env than your shell) — not a missing API key.
     const SMART_ADD_TIMEOUT_MS = 240_000;
     const cliResult = await foundationExec(binPath, binArgs, {
       cwd: ctx.projectDir,
@@ -588,7 +588,13 @@ async function handleSmartAddPreview(
     if (cliResult.error && !cliResult.stdout.trim()) {
       if (cliResult.exitCode === null) {
         throw new Error(
-          `Smart add timed out after ${SMART_ADD_TIMEOUT_MS / 1000}s. This usually means no API key is configured, so it fell back to the slow Claude CLI provider. Set an API key for fast generation: \`n-dx config claude.api_key <key>\` (or export ANTHROPIC_API_KEY before \`ndx start\`), then restart the dashboard.`,
+          `Smart add timed out after ${SMART_ADD_TIMEOUT_MS / 1000}s — the LLM call never returned. ` +
+            `The Claude CLI provider is in use (this is normal without an API key). ` +
+            `Verify the CLI works from the environment that launched the dashboard: ` +
+            `\`time claude -p "hi"\`. If that hangs, the \`claude\` CLI isn't usable there ` +
+            `(re-auth with \`claude\`, or run \`ndx start\` from a shell where it works). ` +
+            `An API key (\`n-dx config claude.api_key\`) is an optional faster path, not required.` +
+            (cliResult.stderr.trim() ? `\n\nstderr:\n${cliResult.stderr.trim()}` : ""),
         );
       }
       throw new Error(cliResult.stderr || cliResult.error.message);

--- a/packages/web/src/server/routes-rex-analysis.ts
+++ b/packages/web/src/server/routes-rex-analysis.ts
@@ -582,12 +582,23 @@ async function handleSmartAddPreview(
     // itself stalled in the server context (e.g. token refresh with no TTY,
     // or a different PATH/env than your shell) — not a missing API key.
     const SMART_ADD_TIMEOUT_MS = 240_000;
+    const startedAt = Date.now();
+    console.log(`[smart-add-preview] spawn`, { binPath, binArgs, cwd: ctx.projectDir });
     const cliResult = await foundationExec(binPath, binArgs, {
       cwd: ctx.projectDir,
       timeout: SMART_ADD_TIMEOUT_MS,
       maxBuffer: 10 * 1024 * 1024,
       env: process.env,
     });
+    const elapsedMs = Date.now() - startedAt;
+    console.log(`[smart-add-preview] finished in ${elapsedMs}ms`, {
+      exitCode: cliResult.exitCode,
+      stdoutBytes: cliResult.stdout.length,
+      stderrBytes: cliResult.stderr.length,
+    });
+    if (cliResult.stderr.trim()) {
+      console.log(`[smart-add-preview] stderr:\n${cliResult.stderr.trim()}`);
+    }
 
     if (cliResult.error && !cliResult.stdout.trim()) {
       if (cliResult.exitCode === null) {

--- a/packages/web/src/server/routes-rex-analysis.ts
+++ b/packages/web/src/server/routes-rex-analysis.ts
@@ -478,7 +478,15 @@ async function handleAcceptEditedProposals(
       let epicId: string;
       if (p.epic.existingId && knownIds.has(p.epic.existingId)) {
         epicId = p.epic.existingId;
+        console.log(`[accept-edited] reuse epic id=${epicId} title="${p.epic.title}"`);
       } else {
+        if (p.epic.existingId) {
+          console.log(
+            `[accept-edited] payload epic.existingId="${p.epic.existingId}" not found in PRD — creating new`,
+          );
+        } else {
+          console.log(`[accept-edited] no existingId for epic "${p.epic.title}" — creating new`);
+        }
         epicId = randomUUID();
         const epicItem: PRDItem = {
           id: epicId,
@@ -498,6 +506,7 @@ async function handleAcceptEditedProposals(
         let featureId: string;
         if (f.existingId && knownIds.has(f.existingId)) {
           featureId = f.existingId;
+          console.log(`[accept-edited] reuse feature id=${featureId} title="${f.title}"`);
         } else {
           featureId = randomUUID();
           const featureItem: PRDItem = {

--- a/packages/web/src/server/routes-rex-analysis.ts
+++ b/packages/web/src/server/routes-rex-analysis.ts
@@ -565,7 +565,11 @@ async function handleSmartAddPreview(
     // Pass description via --description flag (not positional) to prevent any
     // stale UI text from being concatenated into the argument list.
     const description = String(input.text).trim();
-    const args = ["add", "--format=json", "--description", description];
+    // The dashboard preview is a draft the user reviews — `--fast` forces the
+    // vendor's light tier (e.g. haiku) so the CLI provider completes well
+    // within the timeout from a daemonized server. The user-driven CLI
+    // `n-dx add` keeps the configured top-tier model.
+    const args = ["add", "--format=json", "--fast", "--description", description];
     if (input.parentId) args.push("--parent", input.parentId);
     args.push(ctx.projectDir);
 

--- a/packages/web/src/viewer/components/prd-tree/prd-tree.ts
+++ b/packages/web/src/viewer/components/prd-tree/prd-tree.ts
@@ -205,6 +205,9 @@ interface UsageCellArgs {
 
 function renderUsageCell(args: UsageCellArgs) {
   const { item, usageRollup, usage, showTokenBudget, utilization } = args;
+  // The whole cell is gated on the showTokenBudget feature flag — when
+  // budgets aren't active, the column is just noise on every row.
+  if (!showTokenBudget) return null;
 
   // Prefer the server-emitted rollup (works for every level). Fall back
   // to the flat self-only taskUsage entry when the rollup isn't present
@@ -389,6 +392,13 @@ interface NodeRowProps {
   searchQuery?: string;
   /** Whether this node directly matches the search query. */
   isSearchMatch?: boolean;
+  /**
+   * Render the level badge as a "section header" above this row. True only
+   * for the first item in each contiguous group of same-level siblings, so
+   * the badge labels the indentation level once instead of repeating on
+   * every row.
+   */
+  showLevelLabel?: boolean;
 }
 
 /**
@@ -422,6 +432,7 @@ class NodeRow extends Component<NodeRowProps> {
     if (p.canInlineAdd !== nextProps.canInlineAdd) return true;
     if (p.canDelete !== nextProps.canDelete) return true;
     if (p.showTokenBudget !== nextProps.showTokenBudget) return true;
+    if (p.showLevelLabel !== nextProps.showLevelLabel) return true;
     // taskUsage / usageRollup are objects — reference check
     // (new object ⇒ re-render)
     if (p.taskUsage !== nextProps.taskUsage) return true;
@@ -437,7 +448,7 @@ class NodeRow extends Component<NodeRowProps> {
   }
 
   render() {
-    const { item, taskUsage, usageRollup, weeklyBudget, showTokenBudget, tickMs, depth, isExpanded, hasChildren, isSelected, isBulkSelected, canInlineAdd, isInlineAddActive, isHighlighted, nodeRef, canDelete, isDeleting, searchQuery, isSearchMatch } = this.props;
+    const { item, taskUsage, usageRollup, weeklyBudget, showTokenBudget, tickMs, depth, isExpanded, hasChildren, isSelected, isBulkSelected, canInlineAdd, isInlineAddActive, isHighlighted, nodeRef, canDelete, isDeleting, searchQuery, isSearchMatch, showLevelLabel } = this.props;
     const children = item.children ?? [];
     const stats = hasChildren ? computeBranchStats(children) : null;
     const ratio = stats ? completionRatio(stats) : 0;
@@ -485,8 +496,12 @@ class NodeRow extends Component<NodeRowProps> {
       ),
       // Status icon
       h(StatusIndicator, { status: item.status }),
-      // Level badge
-      h("span", { class: `prd-level-badge prd-level-${item.level}` }, LEVEL_LABELS[item.level]),
+      // Level badge — only on the first item of each contiguous same-level
+      // sibling group, so the indentation level reads as a section header
+      // instead of a repeating badge on every row.
+      showLevelLabel
+        ? h("span", { class: `prd-level-badge prd-level-${item.level}` }, LEVEL_LABELS[item.level])
+        : null,
       // Branch badge (only when attribution is present)
       item.branch
         ? h(BranchBadge, { branch: item.branch, sourceFile: item.sourceFile })
@@ -514,15 +529,10 @@ class NodeRow extends Component<NodeRowProps> {
       item.tags && item.tags.length > 0
         ? h(TagList, { tags: item.tags })
         : null,
-      // Token usage column — rollup-aware; renders `—` when no runs
-      // have touched this item or its subtree so empty rows don't read
-      // as "zero work" (per brief).
+      // Token usage column — only when the showTokenBudget feature flag
+      // is enabled. Duration + timestamps live in the detail flyout, not
+      // on every row.
       renderUsageCell({ item, usageRollup, usage, showTokenBudget, utilization }),
-      // Duration column — live-updating for in-progress rows, static
-      // for terminal rows, `—` when no work has been recorded yet.
-      renderDurationCell({ item, usageRollup, hasChildren, tickMs }),
-      // Timestamp
-      h(TimestampSuffix, { item }),
       // ── Inline action group (hover-reveal) ──────────────────────────
       // Unified action row: [+Add] [✎Edit] [↕Status] [✕Delete]
       // All buttons use delegated click handling on the tree container.
@@ -1058,10 +1068,14 @@ export function PRDTree({ document: doc, taskUsageById, rollupById, weeklyBudget
           })
         : null,
       // Visible items — flat rendering from virtual scroll
-      virtualScroll.visibleNodes.map((node: FlatNode) => {
+      virtualScroll.visibleNodes.map((node: FlatNode, idx: number) => {
         const { item, depth, isExpanded, hasChildren } = node;
         const isInlineAddActive = inlineAddParentId === item.id;
         const isHL = highlightedItemId === item.id;
+        // First item of each contiguous same-level group gets the level
+        // badge as a section header; subsequent rows omit it.
+        const prev = idx > 0 ? virtualScroll.visibleNodes[idx - 1] : null;
+        const showLevelLabel = !prev || prev.item.level !== item.level || prev.depth !== depth;
 
         // Only in-progress rows receive the live tick. Idle rows
         // receive `null` so their `shouldComponentUpdate` short-circuits.
@@ -1088,6 +1102,7 @@ export function PRDTree({ document: doc, taskUsageById, rollupById, weeklyBudget
             isDeleting: deletingItemId === item.id,
             searchQuery,
             isSearchMatch: searchMatchIds?.has(item.id),
+            showLevelLabel,
           }),
           // Inline add form — rendered below the parent node
           isInlineAddActive && onInlineAddSubmit

--- a/packages/web/src/viewer/components/prd-tree/proposal-editor.ts
+++ b/packages/web/src/viewer/components/prd-tree/proposal-editor.ts
@@ -23,7 +23,7 @@ export interface ProposalEditorProps {
 
 /** Raw proposal shape from the analyze endpoint. */
 export interface RawProposal {
-  epic: { title: string; source: string; description?: string };
+  epic: { title: string; source: string; description?: string; existingId?: string };
   features: RawProposalFeature[];
 }
 
@@ -31,6 +31,8 @@ interface RawProposalFeature {
   title: string;
   source: string;
   description?: string;
+  /** If present, accept-edited nests new tasks under this existing feature. */
+  existingId?: string;
   tasks: RawProposalTask[];
 }
 
@@ -57,6 +59,8 @@ interface EditableTask {
 interface EditableFeature {
   title: string;
   description: string;
+  /** Carried from RawProposal for smart-placement nesting on accept. */
+  existingId?: string;
   tasks: EditableTask[];
   selected: boolean;
   expanded: boolean;
@@ -66,6 +70,8 @@ interface EditableFeature {
 interface EditableProposal {
   epicTitle: string;
   epicDescription: string;
+  /** Carried from RawProposal for smart-placement nesting on accept. */
+  epicExistingId?: string;
   features: EditableFeature[];
   selected: boolean;
   expanded: boolean;
@@ -84,11 +90,13 @@ function toEditable(proposals: RawProposal[]): EditableProposal[] {
   return proposals.map((p) => ({
     epicTitle: p.epic.title,
     epicDescription: p.epic.description ?? "",
+    ...(p.epic.existingId ? { epicExistingId: p.epic.existingId } : {}),
     selected: true,
     expanded: true,
     features: p.features.map((f) => ({
       title: f.title,
       description: f.description ?? "",
+      ...(f.existingId ? { existingId: f.existingId } : {}),
       selected: true,
       expanded: false,
       tasks: f.tasks.map((t) => ({
@@ -283,10 +291,15 @@ export function ProposalEditor({ proposals: rawProposals, onAccepted, onCancel }
     try {
       const payload = proposals
         .map((p) => ({
-          epic: { title: p.epicTitle, description: p.epicDescription || undefined },
+          epic: {
+            title: p.epicTitle,
+            description: p.epicDescription || undefined,
+            ...(p.epicExistingId ? { existingId: p.epicExistingId } : {}),
+          },
           features: p.features.map((f) => ({
             title: f.title,
             description: f.description || undefined,
+            ...(f.existingId ? { existingId: f.existingId } : {}),
             tasks: f.tasks.map((t) => ({
               title: t.title,
               description: t.description || undefined,

--- a/packages/web/src/viewer/components/prd-tree/smart-add-input.ts
+++ b/packages/web/src/viewer/components/prd-tree/smart-add-input.ts
@@ -201,12 +201,19 @@ export function SmartAddInput({ onPrdChanged, compact }: SmartAddInputProps) {
 
     setAccepting(true);
     try {
-      // Build the payload in the edited-proposals format (all selected)
+      // Build the payload in the edited-proposals format (all selected).
+      // Forward `existingId` from smart-placement so the server nests the new
+      // work under the matched epic/feature instead of duplicating it.
       const payload = proposals.map((p) => ({
-        epic: { title: p.epic.title, description: p.epic.description },
+        epic: {
+          title: p.epic.title,
+          description: p.epic.description,
+          ...(p.epic.existingId ? { existingId: p.epic.existingId } : {}),
+        },
         features: p.features.map((f) => ({
           title: f.title,
           description: f.description,
+          ...(f.existingId ? { existingId: f.existingId } : {}),
           tasks: f.tasks.map((t) => ({
             title: t.title,
             description: t.description,

--- a/packages/web/src/viewer/styles/import-graph.css
+++ b/packages/web/src/viewer/styles/import-graph.css
@@ -1218,21 +1218,20 @@
 }
 
 .ig-graph-shell.ig-street-view-dialog .ig-graph-column {
-  /* Large focused modal — bounded so it isn't edge-to-edge on big monitors,
-     but big on small screens. Flex column so the graph fills the space.
-     Extra specificity so the responsive .ig-graph-column rules can't shrink it. */
-  position: fixed;
-  inset: 4vh 5vw;
-  top: 4vh;
-  left: 5vw;
-  right: 5vw;
-  bottom: 4vh;
+  /* Confined to the Zone Map panel rather than a viewport-level modal.
+     Absolute within .ig-main fills the same area the Zone Map occupies.
+     Flex column so the graph fills the space. */
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
   width: auto;
   height: auto;
-  max-width: 1500px;
-  max-height: 1000px;
-  margin: auto;
-  z-index: 60;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  z-index: 10;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1262,10 +1261,11 @@
 .ig-street-view-dialog .ig-controls,
 .ig-street-view-dialog .ig-type-toggles,
 .ig-street-view-dialog .ig-side,
-.ig-street-view-dialog .ig-street-detail,
-.ig-street-view-dialog .ig-edge-labels {
+.ig-street-view-dialog .ig-street-detail {
   display: none;
 }
+/* Edge labels (cross-zone connector annotations) stay visible in the dialog —
+   the user needs to see what goes where at full size, not just on hover. */
 
 .ig-street-view-dialog .ig-graph-head {
   margin-bottom: 6px;

--- a/packages/web/src/viewer/views/graph.ts
+++ b/packages/web/src/viewer/views/graph.ts
@@ -685,8 +685,13 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
     event.preventDefault();
     const svg = event.currentTarget as SVGSVGElement;
     const mid = touchMidpoint(event.touches);
-    const ratio = touchDistance(event.touches) / p.startDist;
-    updateSurfaceView(p.surface, (view) => zoomMapToFocal(view, p.startK * ratio, mid.x, mid.y, svg));
+    // Dampen the pinch: trackpad finger-spread covers a big distance ratio
+    // for a small physical gesture, so applying it raw makes zoom whippy.
+    // Math.pow(ratio, 0.6) turns a 2× spread into ~1.52× zoom while keeping
+    // the gesture symmetric (1/ratio for pinch-in maps cleanly).
+    const rawRatio = touchDistance(event.touches) / p.startDist;
+    const dampenedRatio = Math.pow(rawRatio, 0.6);
+    updateSurfaceView(p.surface, (view) => zoomMapToFocal(view, p.startK * dampenedRatio, mid.x, mid.y, svg));
   }, [updateSurfaceView]);
 
   const endPinch = useCallback(() => { pinchRef.current = null; }, []);
@@ -1154,24 +1159,42 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
 
   if (mode === "file" && subgraph) {
     const { edges } = subgraph;
-    for (const e of edges) {
+    // Stagger each edge's vertical bend so parallel routes between the same
+    // columns don't stack on the same x — much clearer "what goes to what".
+    // Group by target so siblings ending at the same node fan out cleanly.
+    const targetIndex = new Map<string, number[]>();
+    for (let i = 0; i < edges.length; i++) {
+      const t = edges[i].to;
+      const list = targetIndex.get(t) ?? [];
+      list.push(i);
+      targetIndex.set(t, list);
+    }
+    const edgeShift = new Map<number, number>();
+    for (const [, idxs] of targetIndex) {
+      const n = idxs.length;
+      idxs.forEach((idx, k) => {
+        edgeShift.set(idx, (k - (n - 1) / 2) * 10);
+      });
+    }
+    edges.forEach((e, i) => {
       const a = visualPosMap.get(e.from);
       const b = visualPosMap.get(e.to);
-      if (!a || !b) continue;
+      if (!a || !b) return;
       const wFrom = nodeHalfWidth(kindOf(e.from));
       const wTo = nodeHalfWidth(kindOf(e.to));
       const fromZone = fileToZoneId(e.from, zones);
       const toZone = fileToZoneId(e.to, zones);
       const cross = isCrossZoneEdge(e.from, e.to, zones);
+      const shift = edgeShift.get(i) ?? 0;
       edgePaths.push({
         key: `${e.from}->${e.to}:${e.type}`,
-        d: elbowPath(a.x + wFrom, a.y, b.x - wTo, b.y),
+        d: elbowPath(a.x + wFrom, a.y, b.x - wTo, b.y, shift),
         cross,
         label: cross && zones && fromZone && toZone ? `${zoneDisplayName(zones, fromZone)} -> ${zoneDisplayName(zones, toZone)}` : undefined,
-        labelX: (a.x + b.x) / 2,
+        labelX: (a.x + b.x) / 2 + shift,
         labelY: (a.y + b.y) / 2 - 8,
       });
-    }
+    });
   } else if (mode === "package" && packageSubgraph && focusPackage) {
     const pkgId = `pkg:${focusPackage}`;
     const pkgPos = visualPosMap.get(pkgId);

--- a/packages/web/src/viewer/views/import-graph/layout.ts
+++ b/packages/web/src/viewer/views/import-graph/layout.ts
@@ -98,14 +98,20 @@ export function layoutFocusedGraph(opts: {
   return { nodes, width, height };
 }
 
-/** Polyline path for a directed edge from node a to node b (simple elbow). */
+/**
+ * Polyline path for a directed edge from node a to node b (simple elbow).
+ * `bendShift` offsets the vertical segment's X so parallel edges sharing the
+ * same source-column-to-target-column path don't pile their verticals at the
+ * same X coordinate — pass a small per-edge offset to fan them out.
+ */
 export function elbowPath(
   x1: number,
   y1: number,
   x2: number,
   y2: number,
+  bendShift = 0,
 ): string {
-  const mx = (x1 + x2) / 2;
+  const mx = (x1 + x2) / 2 + bendShift;
   return `M ${x1} ${y1} L ${mx} ${y1} L ${mx} ${y2} L ${x2} ${y2}`;
 }
 

--- a/packages/web/tests/unit/viewer/prd-tree-live-tick-perf.test.ts
+++ b/packages/web/tests/unit/viewer/prd-tree-live-tick-perf.test.ts
@@ -99,10 +99,11 @@ describe("PRDTree live tick at scale", () => {
       }), root);
     });
 
-    // Confirm the tree actually rendered running rows (otherwise the
-    // measurement would be vacuous).
-    const runningCells = root.querySelectorAll(".prd-duration-cell-running");
-    expect(runningCells.length).toBeGreaterThan(0);
+    // Confirm the tree actually rendered in-progress rows (otherwise the
+    // measurement would be vacuous). The duration cell now lives in the
+    // detail flyout, so check the status indicator instead.
+    const runningRows = root.querySelectorAll(".prd-status-in-progress");
+    expect(runningRows.length).toBeGreaterThan(0);
 
     // A second render with a fresh doc reference simulates the tick's
     // effect: a prop identity change in the tree that the virtual-scroll

--- a/packages/web/tests/unit/viewer/prd-tree.test.ts
+++ b/packages/web/tests/unit/viewer/prd-tree.test.ts
@@ -142,6 +142,7 @@ describe("PRDTree", () => {
     const root = renderToDiv(h(PRDTree, {
       document: sampleDoc,
       defaultExpandDepth: 3,
+      showTokenBudget: true,
       taskUsageById: {
         "task-2": { totalTokens: 1234, runCount: 2 },
       },
@@ -177,7 +178,7 @@ describe("PRDTree", () => {
     expect(badge?.getAttribute("data-utilization-reason")).toBe("missing_budget");
   });
 
-  it("hides budget info on token badges when showTokenBudget is false", () => {
+  it("hides the entire token usage cell when showTokenBudget is false", () => {
     const root = renderToDiv(h(PRDTree, {
       document: sampleDoc,
       defaultExpandDepth: 3,
@@ -187,17 +188,19 @@ describe("PRDTree", () => {
         "task-2": { totalTokens: 1234, runCount: 2 },
       },
     }));
-    // Token count still visible
-    expect(root.textContent).toContain("1,234 tokens");
-    // Budget percentage should NOT appear
-    expect(root.textContent).not.toContain("| 2%");
-    // No utilization-reason data attribute
-    const badge = root.querySelector(".prd-token-badge");
-    expect(badge?.getAttribute("data-utilization-reason")).toBeNull();
+    // Whole cell is gated on the feature flag now — no token text, no badge,
+    // no empty-dash placeholder.
+    expect(root.textContent).not.toContain("1,234 tokens");
+    expect(root.querySelector(".prd-token-badge")).toBeNull();
+    expect(root.querySelector(".prd-usage-cell")).toBeNull();
   });
 
   it("renders empty-dash usage cells for rows with no runs (never `0 tokens`)", () => {
-    const root = renderToDiv(h(PRDTree, { document: sampleDoc, defaultExpandDepth: 3 }));
+    const root = renderToDiv(h(PRDTree, {
+      document: sampleDoc,
+      defaultExpandDepth: 3,
+      showTokenBudget: true,
+    }));
     // "No runs yet" must not read as zero work — empty cells render as `—`.
     expect(root.textContent).not.toContain("0 tokens");
     // Active-work filter hides `task-1` (completed). `task-2` (in_progress)
@@ -208,20 +211,6 @@ describe("PRDTree", () => {
     // Nothing in those cells has the active token-badge class.
     const badges = root.querySelectorAll(".prd-token-badge");
     expect(badges.length).toBe(0);
-  });
-
-  it("shows token badge when showTokenBudget is false and usage is non-zero", () => {
-    const root = renderToDiv(h(PRDTree, {
-      document: sampleDoc,
-      defaultExpandDepth: 3,
-      showTokenBudget: false,
-      taskUsageById: {
-        "task-2": { totalTokens: 5000, runCount: 1 },
-      },
-    }));
-    const badge = root.querySelector(".prd-token-badge");
-    expect(badge).not.toBeNull();
-    expect(badge?.textContent).toBe("5,000 tokens");
   });
 
   it("shows token badge when showTokenBudget is true and usage is non-zero", () => {
@@ -241,12 +230,15 @@ describe("PRDTree", () => {
   });
 
   it("renders per-item rollup with self vs. descendant breakdown", () => {
+    // Use an epic (container, not a work item) so the rollup breakdown
+    // branch fires — the work-item budget-chip variant intentionally omits
+    // the self/descendant annotation for compactness on leaf rows.
     const root = renderToDiv(h(PRDTree, {
       document: sampleDoc,
       defaultExpandDepth: 3,
+      showTokenBudget: true,
       rollupById: {
-        // task-2 has children (subtasks) so its rollup includes descendants.
-        "task-2": {
+        "epic-1": {
           self: { totalTokens: 1000, runCount: 1 },
           descendants: { totalTokens: 9000, runCount: 3 },
           total: { totalTokens: 10_000, runCount: 4 },
@@ -258,7 +250,7 @@ describe("PRDTree", () => {
     expect(root.textContent).toContain("(1,000 self)");
   });
 
-  it("renders duration cell for completed tasks with startedAt/completedAt", () => {
+  it("does not render a duration cell on the tree row (duration lives in the detail flyout)", () => {
     const doc: PRDDocumentData = {
       schema: "rex/v1",
       title: "Duration sample",
@@ -268,34 +260,17 @@ describe("PRDTree", () => {
         status: "completed",
         level: "task",
         startedAt: "2026-01-01T00:00:00.000Z",
-        completedAt: "2026-01-01T00:04:10.000Z", // 4m 10s
+        completedAt: "2026-01-01T00:04:10.000Z",
       }],
     };
-    const root = renderToDiv(h(PRDTree, { document: doc, defaultExpandDepth: 1 }));
-    // Completed filter hides completed items; force-include by passing
-    // activeStatuses with all statuses.
-    const root2 = renderToDiv(h(PRDTree, {
+    const root = renderToDiv(h(PRDTree, {
       document: doc,
       defaultExpandDepth: 1,
       activeStatuses: new Set(["completed", "in_progress", "pending"]),
     }));
-    expect(root2.textContent).toContain("4m 10s");
-    // Smoke-check the first render doesn't explode
-    expect(root).toBeDefined();
-  });
-
-  it("renders empty-dash duration for tasks that have never started", () => {
-    const doc: PRDDocumentData = {
-      schema: "rex/v1",
-      title: "Never started",
-      items: [{
-        id: "t", title: "Pending", status: "pending", level: "task",
-      }],
-    };
-    const root = renderToDiv(h(PRDTree, { document: doc, defaultExpandDepth: 1 }));
-    const empty = root.querySelector(".prd-duration-cell-empty");
-    expect(empty).not.toBeNull();
-    expect(empty?.textContent).toBe("—");
+    expect(root.querySelector(".prd-duration-cell")).toBeNull();
+    expect(root.querySelector(".prd-duration-cell-empty")).toBeNull();
+    expect(root.textContent).not.toContain("4m 10s");
   });
 
   it("renders tree role for accessibility", () => {


### PR DESCRIPTION
## Summary

  Focused branch tackling a recurring `n-dx add` epic-duplication bug, fixing the dashboard Quick Add
  flow end-to-end (it was 240 s timing out, then it was silently dropping accepted items, then it was
  duplicating epics again), and a round of PRD-tree row decluttering. Grouped by area:

  ### `n-dx add` nesting & smart placement
  - Deterministic post-LLM placement pass matches proposed epics/features against existing PRD
  containers and fills `existingId` so a new task nests instead of creating a duplicate epic (#210
  family). Trust the dedup scorer's verdict (0.7 threshold) rather than an extra-strict 0.85 gate that
  silently dropped real content-overlap matches.
  - Validate LLM-set `existingId`s against the actual id set — the LLM frequently hallucinates ids;
  bogus ones are discarded so the matcher can find a real candidate.
  - Preserve `existingId` through `attachDuplicateReasonsToProposals` (the JSON serializer for web
  output stripped it; that was THE bug that made the dashboard duplicate epics even after the LLM
  identified the match).
  - Only auto-nest a feature when its epic is also being reused — avoids cross-epic nesting (covered by
   an existing orphaned-parent regression test).

  ### Dashboard Quick Add
  - `applySmartPlacement` (above) applies here too.
  - `--fast` flag on `rex add` forces the light tier (haiku for Claude, gpt-5.4-mini for Codex) so the
  CLI provider completes within the timeout from a daemonized `ndx start`. Web smart-add-preview passes
   it; user-driven CLI `n-dx add` keeps the configured top-tier model.
  - Corrected the haiku model id (`claude-haiku-4-20250414` → `claude-haiku-4-5-20251001`). The old id
  404s on the API and silently hangs on the CLI provider; this was the actual cause of the 240 s
  timeouts.
  - `llm-client/exec()` now closes the child's stdin immediately. `execFile` was leaving stdin
  piped-but-never-closed, so rex's `readStdin()` hung forever waiting for EOF in non-TTY mode. **This
  was the root cause** of the first wave of 240 s zero-output timeouts.
  - Smart-add-preview timeout 60 s → 240 s; smart-add-preview error message rewritten (the Claude CLI
  provider is a valid path, an API key is only an optional speed-up, not a fix).
  - `/api/rex/proposals/accept-edited` now writes through `resolveStore().addItem()` so items land in
  `.rex/prd_tree/` (the authoritative source per CLAUDE.md). Previously it wrote to legacy `prd.md` +
  cache, and the folder-tree watcher overwrote the cache from the unchanged tree — accepted items
  silently vanished.
  - Forward `existingId` from client → server payload → handler so the server reuses the matched
  epic/feature instead of creating a duplicate. Validates against the live PRD's id set; falls back to
  creating new for unknown ids.
  - After accept, `cascadeParentReset` flips any `completed` ancestor back to `pending` (parity with
  the CLI `n-dx add` path).
  - Rex CLI subpath resolution (`@n-dx/rex/dist/cli/index.js` via the server's own install) — fixes
  `Cannot find module` for any non-n-dx project.

  ### PRD tree row decluttering
  - Token usage cell now gated on `showTokenBudget` (no longer renders on every row when budgets aren't
   active).
  - Duration cell and inline timestamp removed from the row — both live in the task detail flyout.
  - Level badge (`EPIC` / `FEATURE` / `TASK` / `SUBTASK`) renders only on the first item of each
  contiguous same-level group, so it acts as a section header for the indentation instead of repeating
  on every row.
  ## Changesets

  All `patch` bumps: `@n-dx/rex`, `@n-dx/web`, `@n-dx/llm-client`.

  ## Test plan

  - [x] `pnpm build`, `pnpm typecheck`, `pnpm docs:build`, `pnpm pr-check`, `pnpm security:obfuscation`
  - [x] Full suites in isolation green: rex 4200, web 2773, llm-client 945, sourcevision unchanged
  - [x] Manual: dashboard Quick Add for a description that maps to an existing epic — accept nests
  under the existing epic, no duplicate; server logs show `[accept-edited] reuse epic id=… title=…`
  (and `reset … -> pending` if the parent was completed)
  - [x] Manual: CLI `n-dx add "…"` for a description that maps to an existing epic — same nesting
  behavior
  - [ ] Manual on reviewer's environment — Quick Add against a non-n-dx project to confirm the rex
  resolver works
  - [ ] Manual — PRD tree row visuals: no token column when `showTokenBudget` is off; no
  duration/timestamp on rows; level badge appears once at each indentation change

  > Note: one rex integration test (`prd-tree-atomic-writes › file-locking: concurrent writers are
  serialized`) can intermittently time out under `pnpm -r run test`'s parallel load — passes
  deterministically in isolation. Pre-existing flake, not introduced here.

  Closes the `n-dx add` duplicate-epic class of issues.