### PR TITLE
fix(web): Rex Tasks view redesign + Quick Add and Start Task fixes

### DIFF
--- a/.changeset/hench-runs-redesign.md
+++ b/.changeset/hench-runs-redesign.md
@@ -1,0 +1,9 @@
+---
+"@n-dx/web": patch
+---
+
+Redesign the Hench Runs view so the run history is the focus. The four
+operational diagnostic panels (concurrency, memory, WebSocket health, throttle)
+that previously stacked above the run list now live in a collapsed "System
+status" drawer at the bottom, and the WebSocket health panel — previously
+rendered with no CSS — is now styled to match the other panels.

--- a/.changeset/quickadd-criteria-start-task-run.md
+++ b/.changeset/quickadd-criteria-start-task-run.md
@@ -1,0 +1,9 @@
+---
+"@n-dx/web": patch
+---
+
+Fix two Tasks-view bugs: Quick Add now persists `acceptanceCriteria` on
+accepted task proposals (it was dropped client-side in both the direct-accept
+and proposal-editor paths), and the dashboard "Start Task" button now launches
+an autonomous hench run for the task via `/api/hench/execute` instead of merely
+flipping its status to in_progress.

--- a/.changeset/tasks-status-dropdown-defaults.md
+++ b/.changeset/tasks-status-dropdown-defaults.md
@@ -1,0 +1,9 @@
+---
+"@n-dx/web": patch
+---
+
+Rework the Rex Tasks view status filter and initial state. The status filter is
+now a multi-select dropdown showing per-status counts with "View all" and
+"Pending only" quick actions. On a fresh load the tree defaults to showing only
+pending items when any exist (otherwise all statuses), and the tree now starts
+fully collapsed.

--- a/.changeset/tasks-view-controls-redesign.md
+++ b/.changeset/tasks-view-controls-redesign.md
@@ -1,0 +1,9 @@
+---
+"@n-dx/web": patch
+---
+
+Redesign the Rex Tasks view controls and fix scrolling. Replaces the stacked
+filter UI with a two-row control bar (search + match count + inline actions on
+top, icon-only status pills + tag typeahead below) and collapses the nested
+scroll regions into a single bounded scroller so the task list is the only thing
+that scrolls.

--- a/packages/web/src/viewer/components/prd-tree/completion-timeline.ts
+++ b/packages/web/src/viewer/components/prd-tree/completion-timeline.ts
@@ -78,6 +78,9 @@ export interface CompletionTimelineProps {
 
 export function CompletionTimeline({ items }: CompletionTimelineProps) {
   const [rangeDays, setRangeDays] = useState(7);
+  // Collapsed by default \u2014 the task tree is the primary surface; this is a
+  // secondary activity feed the user opts into.
+  const [collapsed, setCollapsed] = useState(true);
   const allEntries = useMemo(() => buildTimeline(items), [items]);
 
   const filtered = useMemo(() => {
@@ -96,35 +99,50 @@ export function CompletionTimeline({ items }: CompletionTimelineProps) {
     return groups;
   }, [filtered]);
 
-  return h("div", { class: "completion-timeline" },
-    // Range presets
-    h("div", { class: "timeline-range-bar" },
-      RANGE_PRESETS.map((preset) =>
-        h("button", {
-          key: preset.label,
-          class: `timeline-range-btn${rangeDays === preset.days ? " active" : ""}`,
-          onClick: () => setRangeDays(preset.days),
-        }, preset.label),
-      ),
-      h("span", { class: "timeline-count" }, `${filtered.length} items`),
+  return h("div", { class: `completion-timeline${collapsed ? " collapsed" : ""}` },
+    // Collapsible header \u2014 keeps the footer to a single row when closed.
+    h("button", {
+      class: "timeline-toggle",
+      onClick: () => setCollapsed((c) => !c),
+      "aria-expanded": String(!collapsed),
+      title: collapsed ? "Show recent activity" : "Hide recent activity",
+    },
+      h("span", { class: `timeline-toggle-chevron${collapsed ? "" : " open"}` }, "\u25B8"),
+      h("span", { class: "timeline-toggle-label" }, "Recent activity"),
+      h("span", { class: "timeline-toggle-count" }, `${allEntries.length}`),
     ),
-    // Grouped entries
-    filtered.length === 0
-      ? h("div", { class: "timeline-empty" }, "No completions in this range.")
-      : Array.from(grouped.entries()).map(([day, entries]) =>
-          h("div", { key: day, class: "timeline-day-group" },
-            h("div", { class: "timeline-day-header" }, day),
-            entries.map((entry) =>
-              h("div", { key: entry.id, class: "timeline-entry" },
-                h("span", { class: `timeline-level timeline-level-${entry.level}` }, LEVEL_ICONS[entry.level] || "\u25CF"),
-                h("span", { class: "timeline-title" }, entry.title),
-                entry.parentChain.length > 0
-                  ? h("span", { class: "timeline-breadcrumb" }, entry.parentChain.join(" \u203A "))
-                  : null,
-                h("span", { class: "timeline-time" }, formatTime(entry.completedAt)),
-              ),
+    collapsed
+      ? null
+      : h("div", { class: "timeline-body" },
+          // Range presets
+          h("div", { class: "timeline-range-bar" },
+            RANGE_PRESETS.map((preset) =>
+              h("button", {
+                key: preset.label,
+                class: `timeline-range-btn${rangeDays === preset.days ? " active" : ""}`,
+                onClick: () => setRangeDays(preset.days),
+              }, preset.label),
             ),
+            h("span", { class: "timeline-count" }, `${filtered.length} items`),
           ),
+          // Grouped entries
+          filtered.length === 0
+            ? h("div", { class: "timeline-empty" }, "No completions in this range.")
+            : Array.from(grouped.entries()).map(([day, entries]) =>
+                h("div", { key: day, class: "timeline-day-group" },
+                  h("div", { class: "timeline-day-header" }, day),
+                  entries.map((entry) =>
+                    h("div", { key: entry.id, class: "timeline-entry" },
+                      h("span", { class: `timeline-level timeline-level-${entry.level}` }, LEVEL_ICONS[entry.level] || "\u25CF"),
+                      h("span", { class: "timeline-title" }, entry.title),
+                      entry.parentChain.length > 0
+                        ? h("span", { class: "timeline-breadcrumb" }, entry.parentChain.join(" \u203A "))
+                        : null,
+                      h("span", { class: "timeline-time" }, formatTime(entry.completedAt)),
+                    ),
+                  ),
+                ),
+              ),
         ),
   );
 }

--- a/packages/web/src/viewer/components/prd-tree/facet-filter.ts
+++ b/packages/web/src/viewer/components/prd-tree/facet-filter.ts
@@ -183,11 +183,12 @@ export function FacetFilter({
               class: `prd-facet-chip prd-facet-status${isActive ? " active" : ""} ${sf.cssClass}`,
               onClick: () => toggleStatus(sf.status),
               title: `${isActive ? "Hide" : "Show"} ${sf.label.toLowerCase()} items`,
+              "aria-label": `${sf.label} (${isActive ? "shown" : "hidden"})`,
               "aria-pressed": String(isActive),
               type: "button",
             },
+            // Icon-only pill — label is available via title / aria-label.
             h("span", { class: "prd-facet-chip-icon" }, sf.icon),
-            h("span", { class: "prd-facet-chip-label" }, sf.label),
           );
         }),
       ),

--- a/packages/web/src/viewer/components/prd-tree/facet-filter.ts
+++ b/packages/web/src/viewer/components/prd-tree/facet-filter.ts
@@ -32,6 +32,7 @@ const STATUS_FACETS: { status: ItemStatus; label: string; icon: string; cssClass
   { status: "failing",     label: "Failing",     icon: "\u26A0", cssClass: "prd-status-failing" },
   { status: "blocked",     label: "Blocked",     icon: "\u2298", cssClass: "prd-status-blocked" },
   { status: "deferred",    label: "Deferred",    icon: "\u25CC", cssClass: "prd-status-deferred" },
+  { status: "deleted",     label: "Deleted",     icon: "\u2715", cssClass: "prd-status-deleted" },
 ];
 
 /** Max suggestions shown in the typeahead dropdown. */
@@ -46,6 +47,8 @@ export interface FacetFilterProps {
   activeTags: Set<string>;
   /** Currently selected status facets. */
   activeStatuses: Set<ItemStatus>;
+  /** Per-status item counts across the whole PRD. */
+  statusCounts: Record<ItemStatus, number>;
   /** Called when the set of active tags changes. */
   onTagsChange: (tags: Set<string>) => void;
   /** Called when the set of active statuses changes. */
@@ -58,11 +61,57 @@ export function FacetFilter({
   availableTags,
   activeTags,
   activeStatuses,
+  statusCounts,
   onTagsChange,
   onStatusesChange,
   onClearAll,
 }: FacetFilterProps) {
   const hasActiveFacets = activeTags.size > 0 || activeStatuses.size > 0;
+
+  // ── Status dropdown state ────────────────────────────────────────────
+  const [statusOpen, setStatusOpen] = useState(false);
+  const statusRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!statusOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (statusRef.current && !statusRef.current.contains(e.target as Node)) {
+        setStatusOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [statusOpen]);
+
+  // Statuses present in the PRD (count > 0), plus any currently-active ones so
+  // the user can always see and toggle their current selection.
+  const presentStatuses = STATUS_FACETS.filter(
+    (sf) => statusCounts[sf.status] > 0 || activeStatuses.has(sf.status),
+  );
+  const allPresentSet = new Set<ItemStatus>(
+    STATUS_FACETS.filter((sf) => statusCounts[sf.status] > 0).map((sf) => sf.status),
+  );
+
+  const toggleStatus = (status: ItemStatus) => {
+    const next = new Set(activeStatuses);
+    if (next.has(status)) next.delete(status);
+    else next.add(status);
+    onStatusesChange(next);
+  };
+
+  // Trigger-button summary label.
+  const isAllPresent =
+    allPresentSet.size > 0 &&
+    activeStatuses.size === allPresentSet.size &&
+    [...allPresentSet].every((s) => activeStatuses.has(s));
+  const isPendingOnly = activeStatuses.size === 1 && activeStatuses.has("pending");
+  const statusSummary = isAllPresent
+    ? "All statuses"
+    : isPendingOnly
+      ? "Pending only"
+      : activeStatuses.size === 0
+        ? "None"
+        : `${activeStatuses.size} selected`;
 
   // ── Tag typeahead state ──────────────────────────────────────────────
   const [tagQuery, setTagQuery] = useState("");
@@ -124,19 +173,6 @@ export function FacetFilter({
     [activeTags, onTagsChange],
   );
 
-  const toggleStatus = useCallback(
-    (status: ItemStatus) => {
-      const next = new Set(activeStatuses);
-      if (next.has(status)) {
-        next.delete(status);
-      } else {
-        next.add(status);
-      }
-      onStatusesChange(next);
-    },
-    [activeStatuses, onStatusesChange],
-  );
-
   const onInputKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "ArrowDown") {
@@ -173,24 +209,63 @@ export function FacetFilter({
       h("span", { class: "prd-facet-label" }, "Status:"),
       h(
         "div",
-        { class: "prd-facet-chips", role: "toolbar", "aria-label": "Status filters" },
-        STATUS_FACETS.map((sf) => {
-          const isActive = activeStatuses.has(sf.status);
-          return h(
-            "button",
-            {
-              key: sf.status,
-              class: `prd-facet-chip prd-facet-status${isActive ? " active" : ""} ${sf.cssClass}`,
-              onClick: () => toggleStatus(sf.status),
-              title: `${isActive ? "Hide" : "Show"} ${sf.label.toLowerCase()} items`,
-              "aria-label": `${sf.label} (${isActive ? "shown" : "hidden"})`,
-              "aria-pressed": String(isActive),
-              type: "button",
-            },
-            // Icon-only pill — label is available via title / aria-label.
-            h("span", { class: "prd-facet-chip-icon" }, sf.icon),
-          );
-        }),
+        { class: "prd-status-dropdown", ref: statusRef },
+        // Trigger button
+        h(
+          "button",
+          {
+            class: `prd-status-dropdown-trigger${statusOpen ? " open" : ""}`,
+            onClick: () => setStatusOpen((o) => !o),
+            "aria-haspopup": "true",
+            "aria-expanded": String(statusOpen),
+            type: "button",
+          },
+          h("span", { class: "prd-status-dropdown-summary" }, statusSummary),
+          h("span", { class: "prd-status-dropdown-caret", "aria-hidden": "true" }, "▾"),
+        ),
+        // Popover
+        statusOpen
+          ? h(
+              "div",
+              { class: "prd-status-menu", role: "menu" },
+              // Quick actions
+              h(
+                "div",
+                { class: "prd-status-menu-actions" },
+                h("button", {
+                  class: "prd-status-menu-action",
+                  onClick: () => onStatusesChange(new Set(allPresentSet)),
+                  type: "button",
+                }, "View all"),
+                h("button", {
+                  class: "prd-status-menu-action",
+                  onClick: () => onStatusesChange(new Set<ItemStatus>(["pending"])),
+                  disabled: statusCounts.pending === 0,
+                  type: "button",
+                }, "Pending only"),
+              ),
+              // Status checklist
+              ...presentStatuses.map((sf) => {
+                const isActive = activeStatuses.has(sf.status);
+                return h(
+                  "button",
+                  {
+                    key: sf.status,
+                    class: `prd-status-menu-item${isActive ? " active" : ""}`,
+                    onClick: () => toggleStatus(sf.status),
+                    role: "menuitemcheckbox",
+                    "aria-checked": String(isActive),
+                    type: "button",
+                  },
+                  h("span", { class: `prd-status-menu-check${isActive ? " checked" : ""}` },
+                    isActive ? "✓" : ""),
+                  h("span", { class: `prd-status-menu-icon ${sf.cssClass}` }, sf.icon),
+                  h("span", { class: "prd-status-menu-label" }, sf.label),
+                  h("span", { class: "prd-status-menu-count" }, String(statusCounts[sf.status] ?? 0)),
+                );
+              }),
+            )
+          : null,
       ),
     ),
 

--- a/packages/web/src/viewer/components/prd-tree/proposal-editor.ts
+++ b/packages/web/src/viewer/components/prd-tree/proposal-editor.ts
@@ -52,6 +52,8 @@ interface EditableTask {
   description: string;
   priority: string;
   tags: string;
+  /** Carried verbatim from the proposal; not inline-editable in the UI. */
+  acceptanceCriteria: string[];
   selected: boolean;
 }
 
@@ -104,6 +106,7 @@ function toEditable(proposals: RawProposal[]): EditableProposal[] {
         description: t.description ?? "",
         priority: t.priority ?? "",
         tags: (t.tags ?? []).join(", "),
+        acceptanceCriteria: t.acceptanceCriteria ?? [],
         selected: true,
       })),
     })),
@@ -303,6 +306,7 @@ export function ProposalEditor({ proposals: rawProposals, onAccepted, onCancel }
             tasks: f.tasks.map((t) => ({
               title: t.title,
               description: t.description || undefined,
+              acceptanceCriteria: t.acceptanceCriteria.length > 0 ? t.acceptanceCriteria : undefined,
               priority: t.priority || undefined,
               tags: t.tags ? t.tags.split(",").map((s) => s.trim()).filter(Boolean) : undefined,
               selected: t.selected,

--- a/packages/web/src/viewer/components/prd-tree/smart-add-input.ts
+++ b/packages/web/src/viewer/components/prd-tree/smart-add-input.ts
@@ -217,6 +217,9 @@ export function SmartAddInput({ onPrdChanged, compact }: SmartAddInputProps) {
           tasks: f.tasks.map((t) => ({
             title: t.title,
             description: t.description,
+            ...(t.acceptanceCriteria && t.acceptanceCriteria.length > 0
+              ? { acceptanceCriteria: t.acceptanceCriteria }
+              : {}),
             priority: t.priority,
             tags: t.tags,
             selected: true,

--- a/packages/web/src/viewer/hooks/use-persistent-filter.ts
+++ b/packages/web/src/viewer/hooks/use-persistent-filter.ts
@@ -8,7 +8,7 @@
  * The hook returns the current state and a setter, mirroring useState.
  */
 
-import { useState, useCallback } from "preact/hooks";
+import { useState, useCallback, useRef } from "preact/hooks";
 import type { ItemStatus } from "../components/prd-tree/types.js";
 import { defaultStatusFilter } from "../views/status-filter.js";
 
@@ -32,6 +32,12 @@ export interface PersistentFilterState {
   activeStatuses: Set<ItemStatus>;
   /** Update the active statuses (also persists across remounts). */
   setActiveStatuses: (statuses: Set<ItemStatus>) => void;
+  /**
+   * True when a selection was already persisted before this mount (i.e. the
+   * user has interacted, or a smart default was applied earlier this page
+   * session). Lets callers apply a data-derived default only on a fresh load.
+   */
+  hadPersistedSelection: boolean;
 }
 
 /**
@@ -42,6 +48,11 @@ export interface PersistentFilterState {
  * the last selection.
  */
 export function usePersistentFilter(): PersistentFilterState {
+  // Capture, once, whether a selection was already persisted when this
+  // component first mounted. A fresh page load resets the module variable to
+  // null, so this is false on load and true after any prior selection.
+  const hadPersistedSelection = useRef(persistedStatuses !== null).current;
+
   const [activeStatuses, setActiveStatusesLocal] = useState<Set<ItemStatus>>(
     getPersistedStatuses,
   );
@@ -51,5 +62,5 @@ export function usePersistentFilter(): PersistentFilterState {
     setActiveStatusesLocal(statuses);
   }, []);
 
-  return { activeStatuses, setActiveStatuses };
+  return { activeStatuses, setActiveStatuses, hadPersistedSelection };
 }

--- a/packages/web/src/viewer/main.ts
+++ b/packages/web/src/viewer/main.ts
@@ -179,7 +179,9 @@ function App({ scope }: { scope: string | null }) {
     h(Sidebar, { view, onNavigate: handleSidebarNav, manifest: data.manifest, zones: data.zones, sidebarCollapsed, onToggleSidebar: handleToggleSidebar, scope }),
     h("main", {
       id: "main-content",
-      class: "main",
+      // The Tasks (prd) view manages its own internal scroll region, so the
+      // main column becomes a non-scrolling flex container for it.
+      class: `main${view === "prd" ? " main--fill" : ""}`,
       role: "main",
       "aria-label": "Main content",
       onClick: handleTripleClick,

--- a/packages/web/src/viewer/styles/hench-runs.css
+++ b/packages/web/src/viewer/styles/hench-runs.css
@@ -1994,3 +1994,269 @@
     max-width: 140px;
   }
 }
+
+/* ── System status drawer ──────────────────────────────────────────────
+   Operational diagnostics (concurrency, memory, sockets, throttle) live in a
+   collapsed <details> so the run history stays the primary content. */
+.hench-system-status {
+  margin-top: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--bg-surface);
+}
+
+.hench-system-status[open] {
+  background: var(--bg);
+}
+
+.hench-system-status-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  color: var(--text-dim);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-medium);
+}
+
+.hench-system-status-summary::-webkit-details-marker {
+  display: none;
+}
+
+.hench-system-status-summary:hover {
+  color: var(--text);
+}
+
+.hench-system-status-chevron {
+  display: inline-block;
+  font-size: var(--font-xs);
+  transition: transform var(--transition-normal);
+}
+
+.hench-system-status[open] .hench-system-status-chevron {
+  transform: rotate(90deg);
+}
+
+.hench-system-status-label {
+  color: var(--text);
+}
+
+.hench-system-status-hint {
+  margin-left: auto;
+  color: var(--text-dim);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-normal);
+}
+
+.hench-system-status-body {
+  padding: 0 var(--space-4) var(--space-3);
+}
+
+/* The nested panels already have their own margins; trim the last gap. */
+.hench-system-status-body > *:last-child {
+  margin-bottom: 0;
+}
+
+/* ── WebSocket health panel ─────────────────────────────────────────────
+   Matches the concurrency/memory card aesthetic (was previously unstyled). */
+.ws-health-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+  transition: border-color var(--transition-normal), background var(--transition-normal);
+}
+
+.ws-health-panel-degraded {
+  border-color: color-mix(in srgb, var(--orange) 30%, var(--border));
+  background: color-mix(in srgb, var(--orange) 3%, var(--bg-surface));
+}
+
+.ws-health-panel-unhealthy {
+  border-color: color-mix(in srgb, var(--red) 35%, var(--border));
+  background: color-mix(in srgb, var(--red) 4%, var(--bg-surface));
+}
+
+.ws-health-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.ws-health-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ws-health-icon {
+  font-size: var(--font-md);
+}
+
+.ws-health-icon-healthy { color: var(--green); }
+.ws-health-icon-degraded { color: var(--orange); }
+.ws-health-icon-unhealthy {
+  color: var(--red);
+  animation: concurrency-pulse 1.5s ease-in-out infinite;
+}
+
+.ws-health-title {
+  margin: 0;
+  font-size: var(--font-md);
+  font-weight: var(--weight-semibold);
+  color: var(--text);
+}
+
+.ws-health-badge {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  padding: 1px var(--space-2);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--green) 14%, transparent);
+  color: var(--green);
+}
+
+.ws-health-badge-degraded {
+  background: color-mix(in srgb, var(--orange) 14%, transparent);
+  color: var(--orange);
+}
+
+.ws-health-badge-unhealthy {
+  background: color-mix(in srgb, var(--red) 14%, transparent);
+  color: var(--red);
+}
+
+.ws-health-connection-count {
+  font-variant-numeric: tabular-nums;
+}
+
+.ws-health-count-value {
+  font-size: var(--font-lg);
+  font-weight: var(--weight-semibold);
+}
+
+.ws-health-count-label {
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+}
+
+/* Progress bars (connections, cleanup success) */
+.ws-health-bar-container {
+  margin-bottom: var(--space-3);
+}
+
+.ws-health-bar-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+  margin-bottom: var(--space-1);
+}
+
+.ws-health-bar-detail {
+  font-variant-numeric: tabular-nums;
+}
+
+.ws-health-bar-track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg-hover);
+  overflow: hidden;
+}
+
+.ws-health-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: var(--accent);
+  transition: width var(--transition-normal);
+}
+
+.ws-health-bar-healthy { background: var(--green); }
+.ws-health-bar-degraded { background: var(--orange); }
+.ws-health-bar-unhealthy { background: var(--red); }
+
+/* Cleanup breakdown */
+.ws-health-cleanup-breakdown {
+  margin-bottom: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-lg);
+  background: var(--bg-hover);
+}
+
+.ws-health-cleanup-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-1);
+}
+
+.ws-health-cleanup-title {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  color: var(--text);
+}
+
+.ws-health-cleanup-recent {
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+}
+
+.ws-health-cleanup-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+  padding: 1px 0;
+}
+
+.ws-health-cleanup-row-warn .ws-health-cleanup-reason {
+  color: var(--orange);
+}
+
+.ws-health-cleanup-count {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Stats row */
+.ws-health-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: var(--space-3);
+}
+
+.ws-health-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ws-health-stat-value {
+  font-size: var(--font-md);
+  font-weight: var(--weight-semibold);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.ws-health-stat-label {
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+}
+
+/* Broadcast failure alert */
+.ws-health-failure-alert {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--red) 8%, transparent);
+  color: var(--red);
+  font-size: var(--font-xs);
+}

--- a/packages/web/src/viewer/styles/layout.css
+++ b/packages/web/src/viewer/styles/layout.css
@@ -514,6 +514,18 @@
   padding: var(--space-6);
 }
 
+/* Fill variant — the view owns a single internal scroll region (Tasks view).
+   The main column stops being the scroller and becomes a height-bounded flex
+   column so the view's own scroll area fills the remaining space. */
+.main--fill {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.main--fill > .page-context-bar {
+  flex: none;
+}
+
 /* Detail panel */
 .detail-panel {
   width: var(--panel-w);

--- a/packages/web/src/viewer/styles/prd-tree.css
+++ b/packages/web/src/viewer/styles/prd-tree.css
@@ -5826,14 +5826,127 @@
   font-size: var(--font-xs);
 }
 
-/* Icon-only status pills — compact, legible glyph. */
-.prd-facet-status {
+/* ── Status multi-select dropdown ──────────────────────────────────────── */
+.prd-status-dropdown {
+  position: relative;
+}
+
+.prd-status-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 140px;
+  justify-content: space-between;
   padding: 3px var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text);
+  font-size: var(--font-xs);
+  cursor: pointer;
+  transition: border-color 0.15s;
 }
-.prd-facet-status .prd-facet-chip-icon {
+
+.prd-status-dropdown-trigger:hover,
+.prd-status-dropdown-trigger.open {
+  border-color: var(--accent);
+}
+
+.prd-status-dropdown-caret {
+  color: var(--text-dim);
+  font-size: var(--font-xs);
+}
+
+.prd-status-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  min-width: 220px;
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.18));
+}
+
+.prd-status-menu-actions {
+  display: flex;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-1);
+}
+
+.prd-status-menu-action {
+  flex: 1;
+  padding: 3px var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--text-dim);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.prd-status-menu-action:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.prd-status-menu-action:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.prd-status-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) var(--space-2);
+  border: none;
+  border-radius: 5px;
+  background: none;
+  color: var(--text);
   font-size: var(--font-sm);
-  line-height: 1;
+  cursor: pointer;
+  text-align: left;
 }
+
+.prd-status-menu-item:hover {
+  background: var(--bg-hover);
+}
+
+.prd-status-menu-check {
+  width: 14px;
+  text-align: center;
+  color: var(--accent);
+  font-size: var(--font-xs);
+}
+
+.prd-status-menu-icon {
+  width: 16px;
+  text-align: center;
+}
+
+.prd-status-menu-label {
+  flex: 1;
+}
+
+.prd-status-menu-count {
+  color: var(--text-dim);
+  font-size: var(--font-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.prd-status-menu-item:not(.active) .prd-status-menu-label {
+  color: var(--text-dim);
+}
+
+.prd-status-deleted { color: var(--text-dim); opacity: 0.5; }
 
 .prd-facet-chip-label {
   font-size: var(--font-xs);

--- a/packages/web/src/viewer/styles/prd-tree.css
+++ b/packages/web/src/viewer/styles/prd-tree.css
@@ -5971,14 +5971,56 @@
 /* ── Completion Timeline ───────────────────────────────────────────── */
 
 .completion-timeline {
-  /* Bounded footer in the Tasks view flex column: it can't squeeze the task
-     list above it, and scrolls internally if the history is long. */
+  /* Collapsible footer in the Tasks view flex column. Collapsed by default so
+     the task tree above owns the viewport; the body scrolls internally when
+     expanded and never squeezes the tree below a usable height. */
   flex: none;
-  max-height: 32vh;
-  overflow-y: auto;
-  margin-top: var(--space-3);
+  margin-top: var(--space-2);
   border-top: 1px solid var(--border);
-  padding-top: var(--space-3);
+}
+
+.timeline-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  background: none;
+  border: none;
+  padding: var(--space-2) var(--space-1);
+  cursor: pointer;
+  color: var(--text-dim);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-medium);
+}
+
+.timeline-toggle:hover {
+  color: var(--text);
+}
+
+.timeline-toggle-chevron {
+  display: inline-block;
+  transition: transform 0.15s;
+  font-size: var(--font-xs);
+}
+
+.timeline-toggle-chevron.open {
+  transform: rotate(90deg);
+}
+
+.timeline-toggle-count {
+  margin-left: auto;
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  border-radius: 10px;
+  padding: 0 var(--space-2);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+}
+
+.timeline-body {
+  max-height: 28vh;
+  overflow-y: auto;
+  padding-bottom: var(--space-2);
 }
 
 .timeline-range-bar {

--- a/packages/web/src/viewer/styles/prd-tree.css
+++ b/packages/web/src/viewer/styles/prd-tree.css
@@ -2,14 +2,20 @@
 
 .prd-tree-container {
   padding: 0 var(--space-1);
+  /* Flex column so the tree fills the Tasks view's single scroll region. */
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Header with title and toolbar */
 .prd-header {
+  flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-2);
   flex-wrap: wrap;
   gap: var(--space-2);
 }
@@ -43,7 +49,27 @@
 
 /* Summary bar */
 .prd-summary {
-  margin-bottom: var(--space-5);
+  flex: none;
+  margin-bottom: var(--space-3);
+}
+
+/* Tasks view shell — single internal scroll region.
+   Controls + summary stay pinned; only .prd-tree-virtual scrolls. */
+.prd-view {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.prd-view > .view-header,
+.prd-view > .prd-filter-bar {
+  flex: none;
+}
+/* PRDTree fills the remaining height below the controls. */
+.prd-view > .prd-tree-container {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .prd-summary-bar {
@@ -103,21 +129,19 @@
 .prd-status-dot.prd-status-failing { background: var(--red); opacity: 0.7; }
 .prd-status-dot.prd-status-deferred { background: var(--orange); opacity: 0.5; }
 
-/* Sticky filter bar — consolidated above the tree, persists on scroll */
+/* Control bar — two stacked rows (search/actions, then status+tag filters)
+   pinned above the single scroll region. No longer position:sticky: it's a
+   flex:none row in the Tasks view's flex column, so it stays put while only
+   the tree scrolls. */
 .prd-filter-bar {
-  position: sticky;
-  top: 0;
-  z-index: 10;
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
   background: var(--bg);
-  padding: var(--space-2) 0 var(--space-3);
-  margin-bottom: var(--space-2);
-  /* Subtle bottom edge when floating over scrolled content */
-  border-bottom: 1px solid transparent;
-}
-
-/* Show bottom border only when filter bar is sticky (scrolled past) */
-.prd-filter-bar:not(:first-child) {
-  transition: border-color 0.15s;
+  padding: 0 0 var(--space-3);
+  margin-bottom: var(--space-1);
+  border-bottom: 1px solid var(--border);
 }
 
 /* Status filter */
@@ -377,8 +401,11 @@
    Only items within the viewport plus a buffer zone are rendered; spacer
    elements before/after maintain total scroll height. */
 .prd-tree-virtual {
-  min-height: 120px;
-  max-height: 70vh;
+  /* Single scroll region: fill the remaining height of the Tasks view's flex
+     column rather than being a nested 70vh scroller competing with the page
+     scroll (which felt "weird"). The view pins its controls above this. */
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   /* Smooth scroll for virtual scroll index-based navigation */
   scroll-behavior: smooth;
@@ -5590,7 +5617,6 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin-bottom: var(--space-2);
 }
 
 .prd-search-input {
@@ -5696,11 +5722,13 @@
 
 /* ── Facet filter chips ─────────────────────────────────────────────── */
 
+/* Single wrapping row: status pills + tag filters + clear, all inline. */
 .prd-facet-filter {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-1-5);
-  margin-top: var(--space-1);
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
 }
 
 .prd-facet-row {
@@ -5717,7 +5745,6 @@
   letter-spacing: 0.5px;
   color: var(--text-dim);
   flex-shrink: 0;
-  min-width: 48px;
 }
 
 .prd-facet-chips {
@@ -5797,6 +5824,15 @@
 
 .prd-facet-chip-icon {
   font-size: var(--font-xs);
+}
+
+/* Icon-only status pills — compact, legible glyph. */
+.prd-facet-status {
+  padding: 3px var(--space-2);
+}
+.prd-facet-status .prd-facet-chip-icon {
+  font-size: var(--font-sm);
+  line-height: 1;
 }
 
 .prd-facet-chip-label {
@@ -5935,9 +5971,14 @@
 /* ── Completion Timeline ───────────────────────────────────────────── */
 
 .completion-timeline {
-  margin-top: var(--space-6);
+  /* Bounded footer in the Tasks view flex column: it can't squeeze the task
+     list above it, and scrolls internally if the history is long. */
+  flex: none;
+  max-height: 32vh;
+  overflow-y: auto;
+  margin-top: var(--space-3);
   border-top: 1px solid var(--border);
-  padding-top: var(--space-4);
+  padding-top: var(--space-3);
 }
 
 .timeline-range-bar {

--- a/packages/web/src/viewer/views/hench-runs.ts
+++ b/packages/web/src/viewer/views/hench-runs.ts
@@ -995,18 +995,6 @@ export function HenchRunsView({ navigateTo, initialRunId }: HenchRunsViewProps =
     // Active tasks panel — shown at top when there are running tasks
     h(ActiveTasksPanel, { runs: activeRuns, navigateTo }),
 
-    // Concurrency status — shows process count, limits, and utilization
-    h(ConcurrencyPanel, null),
-
-    // Memory and resource health — system memory, per-task memory, health indicators
-    h(MemoryPanel, null),
-
-    // WebSocket connection health — active connections, cleanup metrics, broadcast stats
-    h(WsHealthPanel, null),
-
-    // Throttle controls — manual concurrency adjustment, pause/resume, emergency stop
-    h(ThrottleControlsPanel, null),
-
     // Aggregate metrics
     h(RunMetrics, { runs }),
 
@@ -1071,6 +1059,22 @@ export function HenchRunsView({ navigateTo, initialRunId }: HenchRunsViewProps =
       filteredRuns.length === 0
         ? h("div", { class: "hench-no-results" }, "No runs match the selected filter.")
         : null,
+    ),
+
+    // System status — operational diagnostics tucked into a collapsed drawer so
+    // the run history stays the focus. Expand to inspect live infrastructure.
+    h("details", { class: "hench-system-status" },
+      h("summary", { class: "hench-system-status-summary" },
+        h("span", { class: "hench-system-status-chevron", "aria-hidden": "true" }, "▸"),
+        h("span", { class: "hench-system-status-label" }, "System status"),
+        h("span", { class: "hench-system-status-hint" }, "concurrency · memory · sockets · throttle"),
+      ),
+      h("div", { class: "hench-system-status-body" },
+        h(ConcurrencyPanel, null),
+        h(MemoryPanel, null),
+        h(WsHealthPanel, null),
+        h(ThrottleControlsPanel, null),
+      ),
     ),
   );
 }

--- a/packages/web/src/viewer/views/prd.ts
+++ b/packages/web/src/viewer/views/prd.ts
@@ -26,7 +26,7 @@ import { PruneConfirmation } from "../components/prd-tree/prune-confirmation.js"
 import { DeleteConfirmation } from "../components/prd-tree/delete-confirmation.js";
 import { BrandedHeader } from "../components/index.js";
 import { CompletionTimeline } from "../components/prd-tree/completion-timeline.js";
-import type { PRDDocumentData } from "../components/prd-tree/index.js";
+import type { PRDDocumentData, ItemStatus } from "../components/prd-tree/index.js";
 import type { DetailItem, NavigateTo } from "../types.js";
 import {
   useToast,
@@ -84,20 +84,35 @@ export function PRDView({ prdData, onSelectItem, onDetailContent, initialTaskId,
   });
 
   // ── Status filter (persists across view switches) ────────────
-  const { activeStatuses, setActiveStatuses } = usePersistentFilter();
+  const { activeStatuses, setActiveStatuses, hadPersistedSelection } = usePersistentFilter();
 
-  // ── Smart expand depth: collapsed when no active work ────────
-  const hasActiveWork = useMemo(() => {
-    if (!data) return false;
-    function check(items: any[]): boolean {
+  // ── Per-status counts (recursive) for the status filter dropdown ──
+  const statusCounts = useMemo(() => {
+    const counts = Object.fromEntries(ALL_STATUSES.map((s) => [s, 0])) as Record<ItemStatus, number>;
+    if (!data) return counts;
+    function walk(items: any[]): void {
       for (const item of items) {
-        if (item.status === "pending" || item.status === "in_progress" || item.status === "blocked") return true;
-        if (item.children && check(item.children)) return true;
+        if (item.status in counts) counts[item.status as ItemStatus]++;
+        if (item.children) walk(item.children);
       }
-      return false;
     }
-    return check(data.items);
+    walk(data.items);
+    return counts;
   }, [data]);
+
+  // ── Smart default: on a fresh load, show only pending when any pending
+  //    tasks exist; otherwise show everything. Skipped once the user has a
+  //    persisted selection so view switches don't clobber their choice. ──
+  const smartDefaultAppliedRef = useRef(false);
+  useEffect(() => {
+    if (smartDefaultAppliedRef.current || hadPersistedSelection || !data) return;
+    smartDefaultAppliedRef.current = true;
+    setActiveStatuses(
+      statusCounts.pending > 0
+        ? new Set<ItemStatus>(["pending"])
+        : new Set<ItemStatus>(ALL_STATUSES),
+    );
+  }, [data, hadPersistedSelection, statusCounts, setActiveStatuses]);
 
   // ── Inline tree search ──────────────────────────────────────────
   const [searchQuery, setSearchQuery] = useState("");
@@ -319,21 +334,22 @@ export function PRDView({ prdData, onSelectItem, onDetailContent, initialTaskId,
         availableTags,
         activeTags,
         activeStatuses,
+        statusCounts,
         onTagsChange: setActiveTags,
         onStatusesChange: setActiveStatuses,
         onClearAll: () => { clearFacets(); setActiveStatuses(new Set(ALL_STATUSES)); },
       }),
     ),
 
-    // PRD tree (key forces remount when expand strategy changes)
+    // PRD tree — starts fully collapsed; the user expands what they need.
     h(PRDTree, {
-      key: `prd-${hasActiveWork ? "active" : "done"}`,
+      key: "prd",
       document: data,
       taskUsageById,
       rollupById,
       weeklyBudget,
       showTokenBudget,
-      defaultExpandDepth: hasActiveWork ? 2 : 0,
+      defaultExpandDepth: 0,
       onSelectItem: actions.handleSelectItem,
       selectedItemId: actions.selectedItemId,
       bulkSelectedIds: actions.bulkSelectedIds,

--- a/packages/web/src/viewer/views/prd.ts
+++ b/packages/web/src/viewer/views/prd.ts
@@ -218,8 +218,8 @@ export function PRDView({ prdData, onSelectItem, onDetailContent, initialTaskId,
   }
 
   return h(
-    Fragment,
-    null,
+    "div",
+    { class: "prd-view" },
 
     // Branded header
     h("div", { class: "view-header" },

--- a/packages/web/src/viewer/views/rex-dashboard.ts
+++ b/packages/web/src/viewer/views/rex-dashboard.ts
@@ -171,10 +171,12 @@ function StartButton({ taskId, onStarted }: { taskId: string; onStarted: () => v
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/rex/items/${taskId}`, {
-        method: "PATCH",
+      // Launch an autonomous hench run for this task. The agent sets the task
+      // to in_progress itself; the dashboard reflects progress via WebSocket.
+      const res = await fetch("/api/hench/execute", {
+        method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "in_progress" }),
+        body: JSON.stringify({ taskId }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
@@ -194,7 +196,7 @@ function StartButton({ taskId, onStarted }: { taskId: string; onStarted: () => v
       class: "rex-dash-start-btn",
       onClick: handleStart,
       disabled: loading,
-      "aria-label": "Start this task",
+      "aria-label": "Run this task with the agent",
     }, loading ? "Starting…" : "Start Task"),
     error
       ? h("div", { class: "rex-dash-start-error", role: "alert" }, error)


### PR DESCRIPTION
  ## Summary
  - Redesign the Rex **Tasks view**: two-row control bar (search + inline actions over a status filter
  + tag typeahead), a single bounded scroll region, a collapsed-by-default tree, and a collapsed
  "Recent activity" footer so the task tree owns the viewport.
  - Replace the status pills with a **multi-select dropdown** showing per-status counts, plus "View
  all" / "Pending only" quick actions. On load the tree defaults to pending-only when pending items
  exist (else all statuses).
  - Fix **Quick Add** dropping `acceptanceCriteria` on accepted proposals (both direct-accept and
  proposal-editor paths).
  - Wire the **Start Task** button to launch an autonomous hench run via `/api/hench/execute` instead
  of only flipping status to in_progress.
  - Redesign the **Hench Runs** view so run history leads, tucking the operational panels (concurrency,
   memory, sockets, throttle) into a collapsed "System status" drawer, and add the missing
  WebSocket-panel styling.

  ## Test plan
  - [ ] Tasks tree fills the viewport; timeline collapsed at the bottom
  - [ ] Status dropdown counts match the PRD; View all / Pending only work; defaults to pending-only on
   load
  - [ ] Quick Add items carry acceptance criteria in the detail flyout
  - [ ] Start Task spawns a run that appears in Hench Runs
  - [ ] Hench Runs leads with history; System status drawer + WebSocket panel render styled