### PR TITLE
Swift analyzer + Architecture/Zones UI redesign + enrichment perf

### DIFF
--- a/.changeset/hench-swift-defaults-and-make-validate.md
+++ b/.changeset/hench-swift-defaults-and-make-validate.md
@@ -1,5 +1,5 @@
 ---
-"@n-dx/hench": minor
+"@n-dx/hench": patch
 ---
 
 Stop assuming every project is JS/TS during `hench init`.

--- a/.changeset/hench-swift-defaults-and-make-validate.md
+++ b/.changeset/hench-swift-defaults-and-make-validate.md
@@ -1,0 +1,21 @@
+---
+"@n-dx/hench": minor
+---
+
+Stop assuming every project is JS/TS during `hench init`.
+
+- Detect Swift projects (`Package.swift`, `*.xcodeproj`, `*.xcworkspace`) and
+  apply a Swift guard profile: `allowedCommands: ["swift", "make",
+  "xcodebuild", "xcrun", "git"]`, Swift-aware blocked paths
+  (`.build/`, `DerivedData/`, `Pods/`, `Carthage/`), and longer timeouts to
+  fit Xcode build times. Adds `"swift"` to `ProjectLanguage`.
+- `autoDetectTestCommand` now prefers a Makefile `validate` target over the
+  raw language toolchain — a strong "project author wrapped the full gate
+  here" signal — and falls back to per-language defaults for Swift (`swift
+  test`), Cargo (`cargo test`), Go (`go test ./...`), and Python (`pytest`)
+  before giving up.
+
+Net effect: on a Swift codebase with a `make validate` gate, `ndx init`
+yields a usable `.hench/config.json` with the right toolchain allowed AND
+the resolver picks up `make validate` automatically — no manual
+`hench.fullTestCommand` override needed.

--- a/.changeset/rex-accept-hashes-mode.md
+++ b/.changeset/rex-accept-hashes-mode.md
@@ -1,5 +1,5 @@
 ---
-"rex": minor
+"rex": patch
 ---
 
 Allow partial accept inside a recommendation group via

--- a/.changeset/rex-accept-hashes-mode.md
+++ b/.changeset/rex-accept-hashes-mode.md
@@ -1,0 +1,10 @@
+---
+"rex": minor
+---
+
+Allow partial accept inside a recommendation group via
+`rex recommend --accept=hashes:<hash>,<hash>,…`. Findings matching the listed
+hash prefixes are filtered first; the recommendation tree is regenerated from
+just those findings and accepted whole. Lets you keep the one valid finding
+inside a noisy group without forcing acks on the rest or having to take the
+group all-or-nothing.

--- a/.changeset/rex-ack-hash-undo-reason.md
+++ b/.changeset/rex-ack-hash-undo-reason.md
@@ -1,5 +1,5 @@
 ---
-"rex": minor
+"rex": patch
 ---
 
 Make `rex recommend` acknowledgement workflow address-by-hash. Each finding

--- a/.changeset/rex-ack-hash-undo-reason.md
+++ b/.changeset/rex-ack-hash-undo-reason.md
@@ -1,0 +1,16 @@
+---
+"rex": minor
+---
+
+Make `rex recommend` acknowledgement workflow address-by-hash. Each finding
+now prints with a stable 6-char hash prefix (`[a3f5d8]`) and
+`--acknowledge=<hash|index>,…` accepts either. Hashes are recommended because
+indices renumber after every ack — a planned `--acknowledge=1,5,9` no longer
+goes wrong when the first ack shifts the list.
+
+Adds `--unacknowledge=<hash|index>,…` to undo prior acknowledgements
+(previously required hand-editing `.rex/acknowledged-findings.json`) and
+`--reason=<category>` to capture *why* — canonical categories are
+`tool-artifact`, `already-done`, `doesnt-apply`, `over-engineered`,
+`speculative`, and free-form values are also accepted. The recorded reason
+will later let the analyzer mine repeated junk and improve its prompts.

--- a/.changeset/sv-cheaper-enrichment.md
+++ b/.changeset/sv-cheaper-enrichment.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Cut enrichment LLM cost and wall-clock without quality regression.

--- a/.changeset/sv-cheaper-enrichment.md
+++ b/.changeset/sv-cheaper-enrichment.md
@@ -1,0 +1,23 @@
+---
+"sourcevision": minor
+---
+
+Cut enrichment LLM cost and wall-clock without quality regression.
+
+**Skip the LLM on structural-only zones.** Zones whose files are entirely
+non-source (build scripts, assets, docs, config — `inventory.role !==
+"source"` for every file) get a templated name and description derived
+from their dominant role and top-level directory. On a typical small repo
+this skips ~30–40 % of zones entirely (gotobed: 4 of 9 — Build & CI
+Scripts, App Bundle Resources, Product Website, Project Root). Quality
+loss is negligible because there's nothing for the LLM to analyze in
+these zones beyond "which directory is this in" — the previous LLM
+output was effectively the same templated paraphrase.
+
+**Use Haiku for pass 1 (naming-dominant), Sonnet for pass 2+.** Pass 1's
+job is mostly zone naming + initial observations; Haiku does that
+accurately in roughly 1/3 the wall-clock of Sonnet and at a fraction of
+the cost. Pass 2+ (cross-zone relationships, anti-patterns, suggestions)
+stays on the standard model so analytical quality doesn't regress.
+Respects `claude.lightModel` / `codex.lightModel` overrides in
+`.n-dx.json` for users who want to pin a specific cheap model.

--- a/.changeset/sv-context-graph-primitives.md
+++ b/.changeset/sv-context-graph-primitives.md
@@ -1,0 +1,21 @@
+---
+"sourcevision": minor
+---
+
+Phase 0 of the context-graph rework: introduces three foundational primitives
+that downstream finding/zone consumers will gate on.
+
+- `Zone.evidenceSources?` (imports / proximity / declared / pinned) and
+  `Zone.confidence?` so consumers can distinguish import-graph-backed zones
+  from proximity-only fallbacks.
+- `Finding.anchors?` (file/line/symbol coordinates) and `Finding.confidence?`
+  so unverified hypotheses can be filtered before reaching the user.
+- New `.sourcevision/project-profile.json` (`ProjectProfile` type) capturing
+  primary language, detected frameworks (SwiftUI, AppKit, React, …),
+  release infrastructure (release-please, changesets, Cargo, pyproject,
+  git-tag build scripts), build and CI surfaces, and import-graph quality.
+
+No behavior changes yet — schema fields are optional and the profile file is
+emitted but not yet consumed by the finding prompt. Subsequent commits gate
+structural findings on `importGraphQuality` and suppress recommendations
+that contradict detected release infrastructure.

--- a/.changeset/sv-context-graph-primitives.md
+++ b/.changeset/sv-context-graph-primitives.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Phase 0 of the context-graph rework: introduces three foundational primitives

--- a/.changeset/sv-edge-weight-by-references.md
+++ b/.changeset/sv-edge-weight-by-references.md
@@ -1,0 +1,13 @@
+---
+"sourcevision": minor
+---
+
+Zone clustering now uses an explicit edge-weight model. `ImportEdge` gained an
+optional `weight` field; Louvain prefers it when set (falling back to
+`symbols.length` for any resolver that hasn't opted in). The Swift resolver
+now reports raw reference counts (a file that references `AppEnvironment` 20
+times is structurally more coupled than one that mentions it once), with each
+edge capped at weight 10 so a single hot edge can't dominate zone assignment.
+Net effect on Swift codebases: composition-root files cluster with the layer
+that uses them heavily, not with the layer whose types they happen to
+import.

--- a/.changeset/sv-edge-weight-by-references.md
+++ b/.changeset/sv-edge-weight-by-references.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Zone clustering now uses an explicit edge-weight model. `ImportEdge` gained an

--- a/.changeset/sv-faster-analyze.md
+++ b/.changeset/sv-faster-analyze.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 "@n-dx/llm-client": patch
 ---
 

--- a/.changeset/sv-faster-analyze.md
+++ b/.changeset/sv-faster-analyze.md
@@ -1,0 +1,29 @@
+---
+"sourcevision": minor
+"@n-dx/llm-client": patch
+---
+
+Make `sv analyze` (and especially `--full`) substantially faster.
+
+- **Parallel enrichment batches.** Previously batches inside a single
+  enrichment pass ran sequentially because each fed an `enrichedNames` hint
+  forward to the next. That hint was advisory (collisions are resolved
+  post-hoc), so batches now run via `Promise.allSettled`. On a typical
+  7-zone repo this roughly halves Phase 4 wall-clock per pass.
+- **Early-exit `--full` on convergence.** The pass loop now fingerprints
+  zone identity + finding/insight counts after each pass and stops as soon
+  as a pass produces no observable change. Stable codebases routinely run
+  4 passes today where 1–2 do all the real work; the rest were dead weight.
+- **`ZONES_PER_BATCH` 5 → 7.** Lets the typical small-to-medium project run
+  in a single batch instead of two.
+- **Tightened file-header excerpts.** Per-file cap 800 → 400 chars,
+  per-batch budget 6 KB → 2.5 KB. Headers are still useful as ground-truth
+  for "is this documented", but the previous budget inflated the full
+  prompt enough to consistently miss the 90 s per-call timeout on slower
+  networks.
+- **Per-call timeout configurable + default bumped.** `claude` CLI
+  invocations now default to 120 s (was 90 s) and respect
+  `NDX_CLAUDE_PER_CALL_TIMEOUT_MS=<ms>` for users on slow networks /
+  larger prompts. The 90 s cap was killing many legitimate-but-slow
+  full-prompt completions before first byte (claude buffers stdout fully,
+  so partial progress is invisible).

--- a/.changeset/sv-headers-and-speculative-filter.md
+++ b/.changeset/sv-headers-and-speculative-filter.md
@@ -1,0 +1,18 @@
+---
+"sourcevision": minor
+---
+
+Stop fabricating findings against documented files. The enrichment prompt now
+includes each batched file's leading doc-comment block as an authoritative
+header excerpt (TS/JS/Swift/Rust/Python/Go/HTML/MD comment conventions are
+recognized). The LLM is explicitly told not to call a documented file
+"undocumented".
+
+Adds a defensive backstop that drops findings whose text begins with a
+hypothesis ("If X then…", "Should/Might/May/Could/Possibly/Perhaps…",
+"It may/might/could/appears/seems…"). Dropped findings are logged with a
+single-line count so the user knows what was filtered. The prompt guard
+already discouraged these; this filter catches the leaks.
+
+Also marks `projectDir` as in-memory-only on `ProjectProfile` so the
+on-disk `.sourcevision/project-profile.json` stays portable across machines.

--- a/.changeset/sv-headers-and-speculative-filter.md
+++ b/.changeset/sv-headers-and-speculative-filter.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Stop fabricating findings against documented files. The enrichment prompt now

--- a/.changeset/sv-jsts-edge-weight.md
+++ b/.changeset/sv-jsts-edge-weight.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Extend the reference-count edge-weight model to JS/TS imports. The resolver

--- a/.changeset/sv-jsts-edge-weight.md
+++ b/.changeset/sv-jsts-edge-weight.md
@@ -1,0 +1,12 @@
+---
+"sourcevision": minor
+---
+
+Extend the reference-count edge-weight model to JS/TS imports. The resolver
+now counts how many times each named-import binding actually appears in the
+file body (after the import statement itself) and uses that as the edge
+weight, capped at 10. Same hub-attraction problem the Swift resolver had: a
+file that imports `cheap-helper` and uses it once shouldn't drag toward
+`cheap-helper`'s zone as hard as a file that uses it 30 times. Wildcard and
+default imports keep the baseline weight 1 because there's no parseable
+local alias to count.

--- a/.changeset/sv-project-shape-prompt.md
+++ b/.changeset/sv-project-shape-prompt.md
@@ -1,0 +1,23 @@
+---
+"sourcevision": minor
+---
+
+Feed the detected project profile into the LLM finding prompt with hard
+constraints that suppress recommendations that don't fit the project's shape:
+
+- When `importGraphQuality` is `sparse` or `absent` (e.g. a Swift, Rust, or
+  Python project with no resolvable JS/TS imports), the LLM is told NOT to
+  emit structural findings — those zones come from file-tree proximity and
+  can't carry meaningful coupling/cohesion claims.
+- When the repo already has release infrastructure (release-please,
+  changesets, package.json, Cargo, pyproject, git-tag build scripts), the LLM
+  is told NOT to recommend introducing a VERSION file or competing release
+  scheme.
+- When SwiftUI is detected as a framework, the LLM is told not to recommend
+  MVVM coordinator/view-model transplants or protocols-for-testability by
+  default.
+- When the primary language is anything other than TS/JS, the LLM is told not
+  to propose JS/TS-specific patterns (e.g. Combine `.replaceError` on a sink
+  whose `Failure` is `Never`).
+- Conditional "If X then Y" findings must be confirmed and rewritten as facts
+  or omitted.

--- a/.changeset/sv-project-shape-prompt.md
+++ b/.changeset/sv-project-shape-prompt.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Feed the detected project profile into the LLM finding prompt with hard

--- a/.changeset/sv-swift-import-resolver.md
+++ b/.changeset/sv-swift-import-resolver.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Add a Swift import + symbol-reference resolver so sourcevision produces a real

--- a/.changeset/sv-swift-import-resolver.md
+++ b/.changeset/sv-swift-import-resolver.md
@@ -1,0 +1,19 @@
+---
+"sourcevision": minor
+---
+
+Add a Swift import + symbol-reference resolver so sourcevision produces a real
+file→file graph on Swift codebases instead of falling back to proximity-only
+zone detection. Swift's `import X` references modules, not files, so a literal
+import parser would produce zero internal edges — this resolver does two
+passes: (1) external `import X` for framework detection (Foundation, SwiftUI,
+AppKit, etc., classified against an Apple stdlib list), and (2) a project-wide
+declaration index (`class/struct/enum/protocol/actor/extension/typealias`)
+plus a reference scan that emits an internal edge for each project-declared
+symbol used in another file. Comments and string literals are stripped before
+both passes so doc-comment mentions don't produce phantom edges.
+
+The result is that `importGraphQuality` flips from `"absent"` to `"rich"` on a
+typical SwiftUI app — Louvain produces meaningful zones with real cohesion,
+and the prompt-side gating no longer needs to suppress every structural
+finding on the project.

--- a/.changeset/sv-swift-language-registry.md
+++ b/.changeset/sv-swift-language-registry.md
@@ -1,0 +1,14 @@
+---
+"sourcevision": patch
+---
+
+Register Swift as a first-class language in the language registry so `.swift`
+files are actually discovered and reach the Swift import resolver. Without
+this, `Package.swift` / `.xcodeproj` projects were being treated as TypeScript
+fallback — `.swift` was filtered out of `parseableExtensions` before phase 2
+ran, leaving the import graph empty even though the Swift resolver was wired
+in. Adds the `swiftConfig` (extensions, test/generated patterns, build/skip
+directories, `Package.swift` as module file), wires it through
+`detectLanguage` / `detectLanguages`, and adds Swift to `VALID_LANGUAGE_IDS`.
+Tiebreak preference on tied counts: TypeScript > Swift > Go (preserves the
+legacy "TS wins go.mod+package.json tie" behavior).

--- a/.changeset/sv-test-quarantine-and-subdivision.md
+++ b/.changeset/sv-test-quarantine-and-subdivision.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": minor
+"sourcevision": patch
 ---
 
 Two complementary partitioning fixes that target the "29-file blob with three

--- a/.changeset/sv-test-quarantine-and-subdivision.md
+++ b/.changeset/sv-test-quarantine-and-subdivision.md
@@ -1,0 +1,27 @@
+---
+"sourcevision": minor
+---
+
+Two complementary partitioning fixes that target the "29-file blob with three
+concerns glued together" failure mode on small/medium repos.
+
+**A. Quarantine out-of-package tests.** When a test file lives in a
+test-only directory (Swift `Tests/<suite>/...`, Vitest/Jest `tests/...`),
+strip it out of Louvain entirely and drop it into its own per-suite
+`tests-<suite>` zone. Tests routinely import production code heavily, which
+previously made Louvain glue the test to whatever it asserted against (a
+classic anti-pattern in the partition).
+
+Tests COLOCATED with their package (Go's `internal/foo/foo_test.go` next
+to `foo.go`) keep their existing behavior — they stay with the package
+because the directory they live in also contains production code, signaling
+"this test belongs here." Detection: a test directory is "test-only" iff
+no production file shares its directory.
+
+**B. Project-relative subdivision threshold.** `SUBDIVISION_THRESHOLD` was
+a flat 50 files, meaning a 29-file zone in a 111-file project (26 % of
+the codebase!) never got recursively subdivided. Now `max(12,
+floor(totalFiles * 0.15))` — any zone over 15 % of the project triggers
+subdivision regardless of how high its measured cohesion is, because high
+cohesion at large size usually means "many concerns connected by shared
+vocabulary," not "one tight thing."

--- a/.changeset/web-finding-card-redesign.md
+++ b/.changeset/web-finding-card-redesign.md
@@ -1,0 +1,20 @@
+---
+"@n-dx/web": patch
+---
+
+Redesign finding cards. The previous "left-bar + severity-tinted background"
+treatment had two problems: a stray `.severity-warning` rule in tables.css
+was washing entire warning cards in dark orange (orange text on orange
+background — unreadable), and the left-bar-per-card pattern has become an
+AI-dashboard tell. New design:
+
+- Cards are a single neutral surface — no severity tint, no left bar.
+- Severity reads from a small colored icon + small-caps label on the meta
+  row. Color sits on the symbol, not on the entire card.
+- Severity, type, and scope live on one quiet meta line separated by `·`
+  instead of three competing badges with their own backgrounds.
+- Body text gets the visual weight: high-contrast, 14 px, generous leading.
+
+The `tables.css` bare `.severity-*` rules are not touched (they still apply
+to real table cells); `.finding-card.severity-*` overrides them via higher
+specificity so finding-card chrome isn't affected.

--- a/.changeset/web-graph-polish.md
+++ b/.changeset/web-graph-polish.md
@@ -1,0 +1,18 @@
+---
+"@n-dx/web": patch
+---
+
+Three Graph-view polish fixes:
+
+- Zone map sizing: the per-zone "Zone Map" SVG was rendering at the full
+  container width × (640/980) ratio, which on a wide screen exploded to
+  >1100px tall and ate the whole viewport. Now pinned to its viewBox aspect
+  ratio with a `max-height: min(60vh, 680px)` cap so the map stays the focus,
+  not the page.
+- Outside-click closes File Street View. Previously only Escape or the Close
+  button worked; clicking outside the dialog shell now closes it too,
+  mirroring conventional modal behavior.
+- Cross-zone edge labels in File Street View are deduplicated. Multiple
+  edges between the same source→target zone pair used to stack identical
+  "UI Overlays → App-Core Bridge" labels. Now one label per pair, with a
+  `×N` count when bundled, positioned at the centroid of the edge bundle.

--- a/.changeset/web-graph-side-by-side.md
+++ b/.changeset/web-graph-side-by-side.md
@@ -1,0 +1,12 @@
+---
+"@n-dx/web": patch
+---
+
+Zone-view layout polish:
+
+- On viewports ≥ 1280px, the Current Selection side panel docks to the right
+  of the Zone Map instead of stacking underneath, so the map and the
+  selection details share the screen instead of forcing a scroll.
+- The Zone Map header "files" stat now shows the selected zone's share of
+  the project (e.g. `5 / 102 files`) so the count is anchored to the whole
+  codebase instead of reading as an unmoored number.

--- a/.changeset/web-graph-spotlight-and-header-cleanup.md
+++ b/.changeset/web-graph-spotlight-and-header-cleanup.md
@@ -1,0 +1,19 @@
+---
+"@n-dx/web": patch
+---
+
+Three Graph-view polish moves:
+
+- File Street View hover spotlight. Hovering an edge highlights it and its
+  two endpoints; hovering a node highlights every edge touching it and the
+  connected nodes; everything else mutes. Cross-zone edge labels show on
+  hover even for non-representative edges. A wide invisible hit area on
+  each edge makes thin lines forgiving to point at.
+- Remove the redundant per-zone "Map of Zone" header (kicker + zone name +
+  zone-only stats) from the in-panel Zone Map. Those stats now live in the
+  scope-card up in the codebase-map section as "Zone Name · X/Y files · N
+  internal · K in / M out", so they're visible without occupying header
+  real estate twice.
+- Wide-screen layout now applies to any `.ig-graph-shell` (not just the
+  zone-active variant) so the Current Selection panel docks to the right at
+  ≥ 1280px regardless of which view you're in.

--- a/.changeset/web-graph-zone-hero-metrics.md
+++ b/.changeset/web-graph-zone-hero-metrics.md
@@ -1,0 +1,13 @@
+---
+"@n-dx/web": patch
+---
+
+When a zone is active in the Graph view, the masthead metric tiles now show
+*zone-scoped* numbers (zone files / project files, internal imports, external
+packages used, neighbor zones) instead of repeating the project totals. The
+previous behavior was misleading — "102 files / 115 imports" stayed in the
+hero even when you'd zoomed into a 5-file zone.
+
+Side-by-side breakpoint lowered to 1100px and reinforced with `!important`
+so the Current Selection panel actually docks to the right on wide screens
+rather than getting silently overridden by the base column layout.

--- a/.changeset/web-street-view-path.md
+++ b/.changeset/web-street-view-path.md
@@ -1,0 +1,7 @@
+---
+"@n-dx/web": patch
+---
+
+Show the focused file path inline next to the "FILE STREET VIEW" kicker so
+the user always knows which file the dependency graph is centered on without
+hunting for the highlighted node.

--- a/packages/hench/src/cli/commands/init.ts
+++ b/packages/hench/src/cli/commands/init.ts
@@ -1,9 +1,25 @@
 import { join } from "node:path";
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import { configExists, ensureHenchDir, initConfig } from "../../store/config.js";
 import { HENCH_DIR } from "./constants.js";
 import { info } from "../output.js";
 import type { ProjectLanguage } from "../../schema/index.js";
+
+/** True when any top-level directory ends in .xcodeproj or .xcworkspace. */
+async function hasXcodeProjectMarker(dir: string): Promise<boolean> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    return entries.some(
+      (e) => e.isDirectory() && (e.name.endsWith(".xcodeproj") || e.name.endsWith(".xcworkspace")),
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try { await access(path); return true; } catch { return false; }
+}
 
 /**
  * Detect the project language for guard configuration.
@@ -11,7 +27,8 @@ import type { ProjectLanguage } from "../../schema/index.js";
  * Detection chain (mirrors sourcevision's logic without importing it):
  * 1. Explicit `.n-dx.json` `language` override
  * 2. `go.mod` present → "go"
- * 3. Otherwise → undefined (JS/TS defaults)
+ * 3. `Package.swift` OR `*.xcodeproj` / `*.xcworkspace` directory → "swift"
+ * 4. Otherwise → undefined (JS/TS defaults)
  */
 async function detectProjectLanguage(dir: string): Promise<ProjectLanguage | undefined> {
   // Step 1: Check .n-dx.json for explicit language override
@@ -20,7 +37,7 @@ async function detectProjectLanguage(dir: string): Promise<ProjectLanguage | und
     const config = JSON.parse(raw) as Record<string, unknown>;
     if (typeof config.language === "string" && config.language !== "auto") {
       const lang = config.language;
-      if (lang === "go" || lang === "typescript" || lang === "javascript") {
+      if (lang === "go" || lang === "swift" || lang === "typescript" || lang === "javascript") {
         return lang;
       }
     }
@@ -29,12 +46,11 @@ async function detectProjectLanguage(dir: string): Promise<ProjectLanguage | und
   }
 
   // Step 2: Check for go.mod marker
-  try {
-    await access(join(dir, "go.mod"));
-    return "go";
-  } catch {
-    // No go.mod — fall through to JS/TS defaults
-  }
+  if (await fileExists(join(dir, "go.mod"))) return "go";
+
+  // Step 3: Check for Swift markers — Package.swift OR an Xcode project.
+  if (await fileExists(join(dir, "Package.swift"))) return "swift";
+  if (await hasXcodeProjectMarker(dir)) return "swift";
 
   return undefined;
 }

--- a/packages/hench/src/schema/v1.ts
+++ b/packages/hench/src/schema/v1.ts
@@ -12,7 +12,7 @@ export const HENCH_SCHEMA_VERSION = "hench/v1";
  * Supported project languages for language-aware guard configuration.
  * "auto" triggers detection during `hench init`.
  */
-export type ProjectLanguage = "typescript" | "javascript" | "go";
+export type ProjectLanguage = "typescript" | "javascript" | "go" | "swift";
 
 /**
  * Configurable subset of policy limits (all optional, defaults applied at runtime).
@@ -224,11 +224,43 @@ const GO_GUARD_DEFAULTS: GuardConfig = {
 };
 
 /**
+ * Guard defaults for Swift projects (SwiftPM / Xcode).
+ *
+ * `swift` covers `swift build`, `swift test`, `swift package …`. `make` is
+ * included because Swift app codebases very commonly wrap their full build +
+ * test + lint gate in a Makefile target (e.g. `make validate`). `xcodebuild`
+ * + `xcrun` cover Xcode-driven builds and CLI tools. `.build/` (SPM build
+ * cache) and `DerivedData/` (Xcode build cache) are blocked so the agent
+ * can't pollute or trip on them.
+ */
+const SWIFT_GUARD_DEFAULTS: GuardConfig = {
+  blockedPaths: [
+    `${PROJECT_DIRS.HENCH}/**`,
+    `${PROJECT_DIRS.REX}/**`,
+    ".git/**",
+    ".build/**",
+    "DerivedData/**",
+    "Pods/**",
+    "Carthage/**",
+  ],
+  allowedCommands: ["swift", "make", "xcodebuild", "xcrun", "git"],
+  commandTimeout: 60000,           // Swift builds are slower than `go test` — 60s.
+  maxFileSize: 1048576,
+  spawnTimeout: 600000,            // 10 minutes — Xcode builds can run long.
+  maxConcurrentProcesses: 3,
+  allowedGitSubcommands: [
+    "status", "add", "commit", "diff", "log",
+    "branch", "checkout", "stash", "show", "rev-parse",
+  ],
+};
+
+/**
  * Returns the language-appropriate guard defaults.
  * Falls back to JS/TS defaults for unknown languages.
  */
 export function guardDefaultsForLanguage(language?: ProjectLanguage): GuardConfig {
   if (language === "go") return { ...GO_GUARD_DEFAULTS };
+  if (language === "swift") return { ...SWIFT_GUARD_DEFAULTS };
   return { ...JS_TS_GUARD_DEFAULTS };
 }
 

--- a/packages/hench/src/tools/test-command-resolver.ts
+++ b/packages/hench/src/tools/test-command-resolver.ts
@@ -10,7 +10,7 @@
  * User-supplied commands are persisted to .hench/config.json for future runs.
  */
 
-import { readFile } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
@@ -58,32 +58,98 @@ async function loadProjectConfig(projectDir: string): Promise<string | undefined
 // Auto-detection from package.json
 // ---------------------------------------------------------------------------
 
+/** True when the file at `path` exists. */
+async function fileExists(path: string): Promise<boolean> {
+  try { await access(path); return true; } catch { return false; }
+}
+
 /**
- * Auto-detect test command from package.json scripts.
- * Checks for "test" or "test:all" scripts (in that order).
+ * True when a Makefile in projectDir defines a `validate` target. A Makefile
+ * `validate` target is a strong signal that the project author has wrapped
+ * their full gate (build + tests + lint + custom checks) behind a single
+ * command — much more reliable than running `swift test` / `cargo test` in
+ * isolation. We accept either GNU Makefile (uppercase M) or "makefile".
+ */
+async function makefileHasValidateTarget(projectDir: string): Promise<boolean> {
+  for (const name of ["Makefile", "makefile", "GNUmakefile"]) {
+    try {
+      const content = await readFile(join(projectDir, name), "utf-8");
+      // Match a target line "validate:" at column 1 (Makefile targets always
+      // start in column 1 — anything indented is a recipe line).
+      if (/^validate\s*:/m.test(content)) return true;
+    } catch {
+      // Try the next filename.
+    }
+  }
+  return false;
+}
+
+/** True when any top-level dir ends in .xcodeproj or .xcworkspace. */
+async function hasXcodeProjectMarker(projectDir: string): Promise<boolean> {
+  try {
+    const entries = await readdir(projectDir, { withFileTypes: true });
+    return entries.some(
+      (e) => e.isDirectory() && (e.name.endsWith(".xcodeproj") || e.name.endsWith(".xcworkspace")),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Auto-detect a full-suite test command from the project shape. Tries, in
+ * order:
+ *
+ * 1. A Makefile `validate` target — this is the canonical "full gate" wrapper
+ *    in many projects (Swift, Go, mixed). If present, prefer it over the
+ *    raw language toolchain so the agent runs the project's actual gate.
+ * 2. `package.json` test:all → npm run test:all.
+ * 3. `package.json` test → npm run test.
+ * 4. `Package.swift` or `.xcodeproj/.xcworkspace` → swift test.
+ * 5. `Cargo.toml` → cargo test.
+ * 6. `go.mod` → go test ./....
+ * 7. `pyproject.toml` or `requirements.txt` → pytest.
+ *
+ * Returns undefined when no signal matches; the resolver then prompts or
+ * surfaces a clear "configure a test command" error.
  */
 async function autoDetectTestCommand(projectDir: string): Promise<string | undefined> {
+  // 1. Makefile `validate` target — strong project-author intent signal.
+  if (await makefileHasValidateTarget(projectDir)) {
+    return "make validate";
+  }
+
+  // 2-3. package.json scripts (existing behaviour, unchanged ordering).
   try {
     const packagePath = join(projectDir, "package.json");
     const content = await readFile(packagePath, "utf-8");
     const pkg = JSON.parse(content) as Record<string, unknown>;
     const scripts = pkg.scripts as Record<string, string> | undefined;
-
-    if (!scripts) return undefined;
-
-    // Prefer "test:all" over "test" for comprehensive suite
-    if (scripts["test:all"]) {
-      return `npm run test:all`;
-    }
-
-    if (scripts["test"]) {
-      return `npm run test`;
-    }
-
-    return undefined;
+    if (scripts?.["test:all"]) return "npm run test:all";
+    if (scripts?.["test"]) return "npm run test";
   } catch {
-    return undefined;
+    // No package.json — continue.
   }
+
+  // 4. Swift project.
+  if (await fileExists(join(projectDir, "Package.swift"))) return "swift test";
+  if (await hasXcodeProjectMarker(projectDir)) return "swift test";
+
+  // 5. Rust.
+  if (await fileExists(join(projectDir, "Cargo.toml"))) return "cargo test";
+
+  // 6. Go.
+  if (await fileExists(join(projectDir, "go.mod"))) return "go test ./...";
+
+  // 7. Python (pyproject or requirements).
+  if (
+    (await fileExists(join(projectDir, "pyproject.toml"))) ||
+    (await fileExists(join(projectDir, "requirements.txt")))
+  ) {
+    return "pytest";
+  }
+
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/hench/tests/unit/tools/test-command-resolver.test.ts
+++ b/packages/hench/tests/unit/tools/test-command-resolver.test.ts
@@ -344,4 +344,69 @@ describe("resolveTestCommand", () => {
       }
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Language- and project-shape auto-detection
+  // ---------------------------------------------------------------------------
+
+  describe("language-aware auto-detect", () => {
+    it("prefers a Makefile validate target over the language toolchain", async () => {
+      // A Swift project that ALSO has Makefile validate — the Makefile wins.
+      await writeFile(join(projectDir, "Package.swift"), "// swift-package");
+      await writeFile(
+        join(projectDir, "Makefile"),
+        "all:\n\techo hi\nvalidate:\n\tswift test\n\tscripts/check.sh\n",
+      );
+      const result = await resolveTestCommand({ projectDir, henchDir });
+      expect(result.command).toBe("make validate");
+      expect(result.source).toBe("auto-detect");
+    });
+
+    it("uses 'swift test' for a Package.swift project without Makefile validate", async () => {
+      await writeFile(join(projectDir, "Package.swift"), "// swift-package");
+      const result = await resolveTestCommand({ projectDir, henchDir });
+      expect(result.command).toBe("swift test");
+      expect(result.source).toBe("auto-detect");
+    });
+
+    it("uses 'swift test' for an Xcode project (.xcodeproj directory)", async () => {
+      await mkdir(join(projectDir, "MyApp.xcodeproj"));
+      const result = await resolveTestCommand({ projectDir, henchDir });
+      expect(result.command).toBe("swift test");
+      expect(result.source).toBe("auto-detect");
+    });
+
+    it("uses 'cargo test' for a Cargo.toml project", async () => {
+      await writeFile(join(projectDir, "Cargo.toml"), '[package]\nname = "x"\nversion = "0.1.0"\n');
+      const result = await resolveTestCommand({ projectDir, henchDir });
+      expect(result.command).toBe("cargo test");
+      expect(result.source).toBe("auto-detect");
+    });
+
+    it("uses 'go test ./...' for a go.mod project (when no package.json wins first)", async () => {
+      await writeFile(join(projectDir, "go.mod"), "module example.com/x\n");
+      const result = await resolveTestCommand({ projectDir, henchDir });
+      expect(result.command).toBe("go test ./...");
+      expect(result.source).toBe("auto-detect");
+    });
+
+    it("uses 'pytest' for a pyproject.toml project", async () => {
+      await writeFile(join(projectDir, "pyproject.toml"), "[project]\nname = 'x'\n");
+      const result = await resolveTestCommand({ projectDir, henchDir });
+      expect(result.command).toBe("pytest");
+      expect(result.source).toBe("auto-detect");
+    });
+
+    it("does NOT mistake an indented 'validate:' line inside a recipe for a target", async () => {
+      // Recipe lines start with a tab and are NOT targets. The detector is
+      // strict about column 1 to avoid this false positive.
+      await writeFile(join(projectDir, "Package.swift"), "// swift-package");
+      await writeFile(
+        join(projectDir, "Makefile"),
+        "all:\n\techo \"  validate: not a target\"\n",
+      );
+      const result = await resolveTestCommand({ projectDir, henchDir });
+      expect(result.command).toBe("swift test");
+    });
+  });
 });

--- a/packages/llm-client/src/cli-provider.ts
+++ b/packages/llm-client/src/cli-provider.ts
@@ -150,8 +150,15 @@ function spawnOnce(
 
     // Per-call timeout — caps any single claude invocation so a stalled
     // process surfaces as a clear, actionable error rather than 240s of
-    // silence (the outer foundationExec timeout).
-    const PER_CALL_TIMEOUT_MS = 90_000;
+    // silence (the outer foundationExec timeout). Configurable via
+    // NDX_CLAUDE_PER_CALL_TIMEOUT_MS so users with slower networks /
+    // larger prompts can extend it without code changes. Defaults bumped
+    // to 120s — 90s killed many legitimate-but-slow first-byte
+    // completions on full-prompt enrichment (claude buffers stdout fully
+    // so partial progress isn't visible).
+    const envTimeout = Number(process.env.NDX_CLAUDE_PER_CALL_TIMEOUT_MS);
+    const PER_CALL_TIMEOUT_MS =
+      Number.isFinite(envTimeout) && envTimeout >= 10_000 ? envTimeout : 120_000;
     const killTimer = setTimeout(() => {
       // Always log — a hung CLI being force-killed is an exceptional event,
       // not per-call noise.

--- a/packages/rex/src/analyze/acknowledge.ts
+++ b/packages/rex/src/analyze/acknowledge.ts
@@ -88,6 +88,52 @@ export function isAcknowledged(store: AcknowledgedStore, hash: string): boolean 
   return store.findings.some((f) => f.hash === hash);
 }
 
+/**
+ * Remove an acknowledgement by hash. Pure — returns a new store. If no
+ * acknowledgement matched the hash the returned store is unchanged.
+ */
+export function unacknowledgeFinding(
+  store: AcknowledgedStore,
+  hash: string,
+): AcknowledgedStore {
+  return {
+    ...store,
+    findings: store.findings.filter((f) => f.hash !== hash),
+  };
+}
+
+/**
+ * Resolve a user-supplied token to a full acknowledged-finding hash. Accepts
+ * the full 12-char hash or any unique 4+ character prefix. Returns `null` if
+ * no match exists; throws if the prefix is ambiguous.
+ */
+export function resolveAckHash(store: AcknowledgedStore, token: string): string | null {
+  const t = token.trim().toLowerCase();
+  if (!t) return null;
+  const matches = store.findings.filter((f) => f.hash.startsWith(t));
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous ack hash "${token}" — matches ${matches.length} acknowledgements. Provide more characters.`,
+    );
+  }
+  return matches[0].hash;
+}
+
+/**
+ * Canonical acknowledgement-reason categories. Free-form values are also
+ * accepted; the canonical set just gives the CLI a discoverable vocabulary
+ * the analyzer can mine later to tune output.
+ */
+export const ACK_REASON_CATEGORIES = [
+  "tool-artifact",
+  "already-done",
+  "doesnt-apply",
+  "over-engineered",
+  "speculative",
+] as const;
+export type AckReasonCategory = typeof ACK_REASON_CATEGORIES[number];
+
 // ── Fuzzy matching ────────────────────────────────────────────────────
 
 function normalizeText(text: string): string {

--- a/packages/rex/src/cli/commands/recommend.ts
+++ b/packages/rex/src/cli/commands/recommend.ts
@@ -12,8 +12,11 @@ import {
   loadAcknowledged,
   saveAcknowledged,
   acknowledgeFinding,
+  unacknowledgeFinding,
+  resolveAckHash,
   isAcknowledged,
   isAcknowledgedFuzzy,
+  ACK_REASON_CATEGORIES,
 } from "../../analyze/acknowledge.js";
 import {
   createItemsFromRecommendations,
@@ -339,36 +342,139 @@ interface AcknowledgeContext {
   findings: Finding[];
 }
 
+/**
+ * Resolve one ack/unack token to a target Finding (or null when no match).
+ * Accepts either a 1-based numeric index into the currently-visible findings
+ * list OR a stable finding-hash prefix (4+ hex chars). The hash form is
+ * preferred because indices renumber after each acknowledgement.
+ */
+function resolveFindingToken(
+  token: string,
+  findings: Finding[],
+): Finding | { error: string } | null {
+  const t = token.trim();
+  if (/^\d+$/.test(t)) {
+    const idx = parseInt(t, 10);
+    if (idx < 1 || idx > findings.length) {
+      return { error: `Index ${idx} out of range (1-${findings.length}).` };
+    }
+    return findings[idx - 1];
+  }
+  if (!/^[0-9a-f]{4,}$/i.test(t)) {
+    return { error: `"${token}" is neither a 1-based index nor a hash prefix (4+ hex chars).` };
+  }
+  const lc = t.toLowerCase();
+  const matches = findings.filter((f) => f.hash.startsWith(lc));
+  if (matches.length === 0) {
+    return { error: `No finding matches hash prefix "${token}". Hashes are shown as [xxxxxx] next to each finding.` };
+  }
+  if (matches.length > 1) {
+    return { error: `Hash prefix "${token}" is ambiguous (${matches.length} matches). Provide more characters.` };
+  }
+  return matches[0];
+}
+
+/**
+ * Validate a --reason value. Free-form is permitted (so users aren't gated by
+ * the canonical list) but unknown reasons get a one-line hint so people
+ * discover the canonical vocabulary the analyzer will mine later.
+ */
+function normalizeReason(input: string | undefined, fallback: string): string {
+  const v = (input ?? "").trim();
+  if (!v) return fallback;
+  const known = ACK_REASON_CATEGORIES as readonly string[];
+  if (!known.includes(v)) {
+    info(`  (--reason "${v}" is free-form; canonical reasons: ${known.join(", ")})`);
+  }
+  return v;
+}
+
 async function handleAcknowledge(
   flag: string,
   ctx: AcknowledgeContext,
+  reasonFlag?: string,
 ): Promise<void> {
   const { rexDir, ackStore, findings } = ctx;
+  const reason = normalizeReason(reasonFlag, "acknowledged");
 
   if (flag === "all") {
     let updated = ackStore;
     for (const f of findings) {
-      updated = acknowledgeFinding(updated, f.hash, f.message, "acknowledged", "user", f.type, f.scope);
+      updated = acknowledgeFinding(updated, f.hash, f.message, reason, "user", f.type, f.scope);
     }
     await saveAcknowledged(rexDir, updated);
-    result(`Acknowledged all ${findings.length} findings.`);
+    result(`Acknowledged all ${findings.length} findings (reason: ${reason}).`);
     return;
   }
 
-  const indices = flag.split(",").map((s) => parseInt(s.trim(), 10));
+  const tokens = flag.split(",").map((s) => s.trim()).filter(Boolean);
   let updated = ackStore;
   const acked: string[] = [];
-  for (const idx of indices) {
-    const f = findings[idx - 1]; // 1-based index
-    if (!f) {
-      console.error(`Finding index ${idx} out of range (1-${findings.length}).`);
+  for (const token of tokens) {
+    const resolved = resolveFindingToken(token, findings);
+    if (!resolved) continue;
+    if ("error" in resolved) {
+      console.error(resolved.error);
       continue;
     }
-    updated = acknowledgeFinding(updated, f.hash, f.message, "acknowledged", "user", f.type, f.scope);
-    acked.push(`${idx}. ${f.message.slice(0, 60)}`);
+    const f = resolved;
+    updated = acknowledgeFinding(updated, f.hash, f.message, reason, "user", f.type, f.scope);
+    acked.push(`[${f.hash.slice(0, 6)}] ${f.message.slice(0, 60)}`);
   }
   await saveAcknowledged(rexDir, updated);
   for (const a of acked) result(`Acknowledged: ${a}`);
+  if (acked.length > 0) result(`(reason: ${reason})`);
+}
+
+/**
+ * Remove acknowledgements. Tokens may be either a hash prefix that matches a
+ * record in the ack store, or a 1-based index into the currently-visible
+ * findings (which the user would typically only see with --show-all).
+ */
+async function handleUnacknowledge(
+  flag: string,
+  ctx: AcknowledgeContext,
+): Promise<void> {
+  const { rexDir, ackStore, findings } = ctx;
+  const tokens = flag.split(",").map((s) => s.trim()).filter(Boolean);
+  let updated = ackStore;
+  const removed: string[] = [];
+  for (const token of tokens) {
+    // Index path — resolve via current findings list (works with --show-all).
+    if (/^\d+$/.test(token)) {
+      const resolved = resolveFindingToken(token, findings);
+      if (resolved && !("error" in resolved)) {
+        if (isAcknowledged(updated, resolved.hash)) {
+          updated = unacknowledgeFinding(updated, resolved.hash);
+          removed.push(`[${resolved.hash.slice(0, 6)}] ${resolved.message.slice(0, 60)}`);
+        } else {
+          console.error(`Finding [${resolved.hash.slice(0, 6)}] is not currently acknowledged.`);
+        }
+      } else if (resolved && "error" in resolved) {
+        console.error(resolved.error);
+      }
+      continue;
+    }
+    // Hash path — resolve against the ack store directly, so users can undo
+    // acks even when the underlying finding no longer surfaces.
+    try {
+      const fullHash = resolveAckHash(updated, token);
+      if (!fullHash) {
+        console.error(`No acknowledgement matches hash prefix "${token}".`);
+        continue;
+      }
+      const acked = updated.findings.find((f) => f.hash === fullHash);
+      updated = unacknowledgeFinding(updated, fullHash);
+      removed.push(`[${fullHash.slice(0, 6)}] ${(acked?.text ?? "").slice(0, 60)}`);
+    } catch (err) {
+      console.error((err as Error).message);
+    }
+  }
+  await saveAcknowledged(rexDir, updated);
+  for (const r of removed) result(`Unacknowledged: ${r}`);
+  if (removed.length === 0) {
+    result("No acknowledgements removed.");
+  }
 }
 
 // ── Display recommendations ─────────────────────────────────────────────
@@ -399,7 +505,10 @@ function displayRecommendations(
       for (const line of task.description.split("\n")) {
         const finding = findings.find((f) => line.includes(f.message));
         const ackMarker = showAll && finding && isAcknowledged(ackStore, finding.hash) ? " (acknowledged)" : "";
-        info(`       ${line.replace(/^- /, "")}${ackMarker}`);
+        // Show the stable 6-char hash so users can ack/unack by ID without
+        // having to count positional indices (which renumber after each ack).
+        const hashPrefix = finding ? `[${finding.hash.slice(0, 6)}] ` : "";
+        info(`       ${hashPrefix}${line.replace(/^- /, "")}${ackMarker}`);
       }
     }
     info("");
@@ -622,7 +731,15 @@ export async function cmdRecommend(
     const findings = showAll
       ? allFindings
       : allFindings.filter((f) => !isAcknowledgedFuzzy(ackStore, { hash: f.hash, type: f.type, scope: f.scope ?? "global", text: f.message }));
-    await handleAcknowledge(flags.acknowledge, { rexDir, ackStore, findings });
+    await handleAcknowledge(flags.acknowledge, { rexDir, ackStore, findings }, flags.reason);
+    return;
+  }
+
+  // Handle --unacknowledge flag — undo prior acknowledgements by hash or index.
+  if (flags.unacknowledge) {
+    // For unack we always want every finding visible so index/hash resolution
+    // matches what the user sees with --show-all.
+    await handleUnacknowledge(flags.unacknowledge, { rexDir, ackStore, findings: allFindings });
     return;
   }
 
@@ -730,6 +847,9 @@ export async function cmdRecommend(
     await acceptRecommendations(rexDir, flags.accept, recommendations, flags);
   } else {
     info("Run with --accept to add all recommendations to the PRD.");
-    info("Run with --acknowledge=1,2 to acknowledge specific findings.");
+    info("Acknowledge findings by stable hash (preferred — survives renumbering):");
+    info("  rex recommend --acknowledge=a3f5d8,b91c42 --reason=over-engineered");
+    info("Indices still work but renumber after each ack: --acknowledge=1,2");
+    info("Undo with --unacknowledge=<hash|index>.");
   }
 }

--- a/packages/rex/src/cli/commands/recommend.ts
+++ b/packages/rex/src/cli/commands/recommend.ts
@@ -101,6 +101,39 @@ function checkRangeSyntax(token: string, context: "full" | "token"): void {
   );
 }
 
+/**
+ * Detect and parse `--accept=hashes:h1,h2,h3` partial-accept mode. Returns
+ * the hash-prefix tokens when the flag uses the hashes selector, or `null`
+ * when it doesn't (so the caller falls back to the index-based selector).
+ *
+ * Accepts both `=hashes:…` and bare `hashes:…` so users don't have to think
+ * about the leading `=` they would otherwise need for numeric selectors.
+ */
+export function parseHashAcceptSelector(flag: string): string[] | null {
+  let body = flag.trim();
+  if (body.startsWith("=")) body = body.slice(1);
+  const PREFIX = "hashes:";
+  if (!body.toLowerCase().startsWith(PREFIX)) return null;
+  const rest = body.slice(PREFIX.length);
+  const tokens = rest
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (tokens.length === 0) {
+    throw selectorFormatError(
+      "Invalid --accept hashes selector. Expected '=hashes:<hash>[,<hash>,...]'.",
+    );
+  }
+  for (const t of tokens) {
+    if (!/^[0-9a-f]{4,}$/i.test(t)) {
+      throw selectorFormatError(
+        `Invalid finding hash "${t}" in --accept. Hashes are 4+ hex chars (see [xxxxxx] in 'rex recommend' output).`,
+      );
+    }
+  }
+  return tokens;
+}
+
 export function parseSelectionIndices(input: string, total: number): number[] {
   const raw = input.trim();
   if (!raw.startsWith("=")) {
@@ -805,6 +838,29 @@ export async function cmdRecommend(
     structuralSkipped = before - filteredFindings.length;
   }
 
+  // --accept=hashes:h1,h2 partial-accept mode: filter the finding list down to
+  // just the selected hashes BEFORE grouping into recommendations, then
+  // implicitly switch the selector to =all so every regenerated recommendation
+  // is created. Lets the user cherry-pick a subset of findings inside what
+  // would otherwise be an all-or-nothing recommendation group.
+  if (flags.accept) {
+    const hashTokens = parseHashAcceptSelector(flags.accept);
+    if (hashTokens) {
+      const normalized = hashTokens.map((t) => t.toLowerCase());
+      const matched = filteredFindings.filter((f) =>
+        normalized.some((h) => f.hash.startsWith(h)),
+      );
+      const unmatched = normalized.filter(
+        (h) => !filteredFindings.some((f) => f.hash.startsWith(h)),
+      );
+      for (const h of unmatched) {
+        console.error(`No finding matches hash prefix "${h}".`);
+      }
+      filteredFindings = matched;
+      flags = { ...flags, accept: "=all" };
+    }
+  }
+
   if (filteredFindings.length === 0) {
     result("No findings to recommend.");
     if (acknowledgedCount > 0) {
@@ -847,7 +903,9 @@ export async function cmdRecommend(
     await acceptRecommendations(rexDir, flags.accept, recommendations, flags);
   } else {
     info("Run with --accept to add all recommendations to the PRD.");
-    info("Acknowledge findings by stable hash (preferred — survives renumbering):");
+    info("Cherry-pick by finding hash (partial accept within a group):");
+    info("  rex recommend --accept=hashes:a3f5d8,b91c42");
+    info("Acknowledge findings by stable hash (survives renumbering):");
     info("  rex recommend --acknowledge=a3f5d8,b91c42 --reason=over-engineered");
     info("Indices still work but renumber after each ack: --acknowledge=1,2");
     info("Undo with --unacknowledge=<hash|index>.");

--- a/packages/rex/tests/unit/cli/commands/recommend.test.ts
+++ b/packages/rex/tests/unit/cli/commands/recommend.test.ts
@@ -73,6 +73,7 @@ describe("cmdRecommend --accept indexed selection", () => {
   let tmpDir: string;
   let cmdRecommend: typeof import("../../../../src/cli/commands/recommend.js")["cmdRecommend"];
   let parseSelectionIndices: typeof import("../../../../src/cli/commands/recommend.js")["parseSelectionIndices"];
+  let parseHashAcceptSelector: typeof import("../../../../src/cli/commands/recommend.js")["parseHashAcceptSelector"];
 
   beforeEach(async () => {
     vi.resetModules();
@@ -88,7 +89,7 @@ describe("cmdRecommend --accept indexed selection", () => {
       setQuiet: () => {},
       isQuiet: () => false,
     }));
-    ({ cmdRecommend, parseSelectionIndices } = await import("../../../../src/cli/commands/recommend.js"));
+    ({ cmdRecommend, parseSelectionIndices, parseHashAcceptSelector } = await import("../../../../src/cli/commands/recommend.js"));
 
     tmpDir = await mkdtemp(join(tmpdir(), "rex-recommend-test-"));
     await writeFixtureProject(tmpDir);
@@ -705,6 +706,45 @@ describe("cmdRecommend --accept indexed selection", () => {
       await cmdRecommend(tmpDir, { accept: "=." });
       const items = await readPrdItems(tmpDir);
       expect(items).toHaveLength(0);
+    });
+  });
+
+  // ── parseHashAcceptSelector ─────────────────────────────────────────
+  describe("parseHashAcceptSelector", () => {
+    it("returns null when the selector is not a hashes mode", () => {
+      expect(parseHashAcceptSelector("=1,2,3")).toBeNull();
+      expect(parseHashAcceptSelector("=all")).toBeNull();
+      expect(parseHashAcceptSelector("true")).toBeNull();
+    });
+
+    it("parses =hashes:h1,h2,h3 and returns the prefixes", () => {
+      expect(parseHashAcceptSelector("=hashes:a3f5d8,b91c42,deadbe"))
+        .toEqual(["a3f5d8", "b91c42", "deadbe"]);
+    });
+
+    it("accepts bare hashes:… without leading =", () => {
+      expect(parseHashAcceptSelector("hashes:abcd,ef01"))
+        .toEqual(["abcd", "ef01"]);
+    });
+
+    it("accepts mixed whitespace and commas", () => {
+      expect(parseHashAcceptSelector("=hashes: abcd , ef01 \tba9c"))
+        .toEqual(["abcd", "ef01", "ba9c"]);
+    });
+
+    it("throws when an entry is not a valid hash prefix", () => {
+      expect(() => parseHashAcceptSelector("=hashes:abcd,zzz"))
+        .toThrowError(/Invalid finding hash "zzz"/i);
+    });
+
+    it("throws when no tokens are provided", () => {
+      expect(() => parseHashAcceptSelector("=hashes:"))
+        .toThrowError(/Expected '=hashes:<hash>/i);
+    });
+
+    it("throws when a single token is too short (<4 hex chars)", () => {
+      expect(() => parseHashAcceptSelector("=hashes:ab"))
+        .toThrowError(/Invalid finding hash "ab"/i);
     });
   });
 });

--- a/packages/sourcevision/src/analyzers/claude-client.ts
+++ b/packages/sourcevision/src/analyzers/claude-client.ts
@@ -41,6 +41,17 @@ function resolveModel(override?: string): string {
 }
 
 /**
+ * Resolve the configured "light" tier model for the active vendor. Used by
+ * enrichment to send naming-dominant pass 1 prompts to a cheaper/faster
+ * model (Haiku for Claude) while keeping analytical pass 2+ on the
+ * standard tier. Respects `claude.lightModel` / `codex.lightModel`
+ * overrides in `.n-dx.json` so users can pin a specific cheap model.
+ */
+export function resolveLightModel(): string {
+  return resolveVendorModel(resolveVendor(), _llmConfig ?? {}, "light");
+}
+
+/**
  * Set the module-level LLM configuration.
  * Call this at CLI entry points before any LLM operations.
  * Resets the cached client so the next call creates a fresh one.

--- a/packages/sourcevision/src/analyzers/enrich-batch.ts
+++ b/packages/sourcevision/src/analyzers/enrich-batch.ts
@@ -12,6 +12,7 @@ import type {
   Zones,
   Finding,
   AnalyzeTokenUsage,
+  ProjectProfile,
 } from "../schema/index.js";
 
 import {
@@ -154,6 +155,7 @@ export async function enrichBatch(
   enrichedNames?: Map<string, string>,
   fileArchetypes?: Map<string, string | null>,
   hints?: string,
+  projectProfile?: ProjectProfile,
 ): Promise<BatchResult | null | { authError: true }> {
   const isFirstPass = passNumber === 1;
   const batchFiles = batchZones.reduce((sum, z) => sum + z.files.length, 0);
@@ -196,8 +198,8 @@ export async function enrichBatch(
       .join("\n");
 
     const prompt = isFirstPass
-      ? buildFirstPassPrompt(batchZones, config, otherContext, priorNames, crossingLines, globalPromptNote, passConfig, fileArchetypes, hints)
-      : buildLaterPassPrompt(batchZones, config, otherContext, crossingLines, passNumber, passConfig, previousZones, globalPromptNote, fileArchetypes, hints);
+      ? buildFirstPassPrompt(batchZones, config, otherContext, priorNames, crossingLines, globalPromptNote, passConfig, fileArchetypes, hints, projectProfile)
+      : buildLaterPassPrompt(batchZones, config, otherContext, crossingLines, passNumber, passConfig, previousZones, globalPromptNote, fileArchetypes, hints, projectProfile);
 
     const promptLevel = config.maxFiles >= 8 ? "full" : config.maxFiles > 0 ? "compact" : "minimal";
     const spinner = startSpinner(
@@ -320,6 +322,92 @@ interface AttemptConfig {
   maxCrossings: number;
 }
 
+/**
+ * Render a "Project shape" section for the LLM prompt that grounds the model
+ * in the repo's actual ecosystem. The model uses this to suppress
+ * recommendations that don't fit (e.g. don't recommend MVVM coordinators on a
+ * SwiftUI app, don't propose a VERSION file when release-please is wired,
+ * don't make structural calls when the import graph is absent/sparse).
+ */
+function formatProjectShape(p: ProjectProfile): string {
+  const lines: string[] = [];
+
+  const langLine = p.languages.length > 1
+    ? `${p.primaryLanguage} (also: ${p.languages.slice(1).join(", ")})`
+    : p.primaryLanguage;
+  lines.push(`Primary language: ${langLine}`);
+
+  if (p.frameworks.length > 0) {
+    lines.push(`Frameworks: ${p.frameworks.join(", ")}`);
+  }
+  if (p.releaseInfrastructure.length > 0) {
+    const kinds = p.releaseInfrastructure.map((r) => `${r.kind} (${r.evidence})`).join(", ");
+    lines.push(`Release infrastructure already present: ${kinds}`);
+  }
+  if (p.buildSurfaces.length > 0) {
+    lines.push(`Build surfaces: ${p.buildSurfaces.map((s) => s.path).join(", ")}`);
+  }
+  if (p.ciSurfaces.length > 0) {
+    lines.push(`CI surfaces: ${p.ciSurfaces.map((s) => s.path).join(", ")}`);
+  }
+  lines.push(`Import graph quality: ${p.importGraphQuality}`);
+
+  // Per-shape anti-recommendations the LLM should respect.
+  const guards: string[] = [];
+
+  if (p.importGraphQuality !== "rich") {
+    guards.push(
+      "Zones in this codebase were assembled from file-tree proximity (no usable import graph). " +
+      "DO NOT emit structural findings about zone boundaries, coupling, or refactor placement. " +
+      "Structural claims require a real import graph to be meaningful — focus instead on code-level " +
+      "observations grounded in the file contents themselves.",
+    );
+  }
+
+  if (p.releaseInfrastructure.length > 0) {
+    const kinds = p.releaseInfrastructure.map((r) => r.kind).join(", ");
+    guards.push(
+      `Version management is already handled by: ${kinds}. ` +
+      `DO NOT recommend introducing a VERSION file, a version constant, or a new release scheme — ` +
+      `that would create a competing source of truth.`,
+    );
+  }
+
+  const hasSwiftUI = p.frameworks.includes("swiftui");
+  if (hasSwiftUI) {
+    guards.push(
+      "This is a SwiftUI codebase. DO NOT recommend MVVM coordinator/view-model patterns transplanted " +
+      "from React/TS — SwiftUI's idiomatic state model is @State/@StateObject/@EnvironmentObject. " +
+      "DO NOT recommend introducing service protocols solely for testability; that is a Java/TS-era reflex " +
+      "and is rarely appropriate for an idiomatic SwiftUI app.",
+    );
+  }
+
+  if (
+    p.primaryLanguage !== "typescript" &&
+    p.primaryLanguage !== "javascript" &&
+    p.primaryLanguage !== "tsx" &&
+    p.primaryLanguage !== "jsx"
+  ) {
+    guards.push(
+      `This is a ${p.primaryLanguage} project, not TypeScript/JavaScript. ` +
+      `DO NOT propose JS/TS framework recommendations (e.g. Combine .replaceError/.catch on a sink whose ` +
+      `Failure is Never; React patterns; npm workflows). Code-level recommendations MUST be idiomatic for ${p.primaryLanguage}.`,
+    );
+  }
+
+  guards.push(
+    "Any finding that begins with a conditional like \"If X then Y\" is a hypothesis. " +
+    "Either confirm the hypothesis from the file contents you can see and rewrite it as a fact, or omit it.",
+  );
+
+  let block = `\nProject shape:\n${lines.map((l) => `  - ${l}`).join("\n")}`;
+  if (guards.length > 0) {
+    block += `\n\nHard constraints derived from the project shape:\n${guards.map((g) => `  - ${g}`).join("\n")}`;
+  }
+  return block + "\n";
+}
+
 function buildFirstPassPrompt(
   batchZones: Zone[],
   config: AttemptConfig,
@@ -330,7 +418,9 @@ function buildFirstPassPrompt(
   passConfig: PassConfig,
   fileArchetypes?: Map<string, string | null>,
   hints?: string,
+  projectProfile?: ProjectProfile,
 ): string {
+  const projectShape = projectProfile ? formatProjectShape(projectProfile) : "";
   if (config.maxFiles > 0) {
     const zoneList = batchZones
       .map((z) => {
@@ -348,7 +438,7 @@ function buildFirstPassPrompt(
     return `Analyze this codebase's zone structure. Each zone groups related files discovered by import-graph community detection.
 
 ${passConfig.focus}
-
+${projectShape}
 Zones:
 ${zoneList}
 ${otherContext}
@@ -383,7 +473,7 @@ Return exactly ${batchZones.length} zone entries. Use finding types: ${passConfi
     .join("\n");
 
   return `Name these code zones. Each groups files by import structure.
-
+${projectShape}
 Zones:
 ${zoneList}
 ${otherContext}
@@ -405,7 +495,9 @@ function buildLaterPassPrompt(
   globalPromptNote: string,
   fileArchetypes?: Map<string, string | null>,
   hints?: string,
+  projectProfile?: ProjectProfile,
 ): string {
+  const projectShape = projectProfile ? formatProjectShape(projectProfile) : "";
   const prevZones = previousZones?.zones ?? [];
   const prevGlobal = previousZones?.insights ?? [];
 
@@ -426,7 +518,7 @@ function buildLaterPassPrompt(
       .join("\n");
 
     return `You previously analyzed this codebase. Here is the current state:
-
+${projectShape}
 Zones:
 ${zoneContext}
 ${otherContext}

--- a/packages/sourcevision/src/analyzers/enrich-batch.ts
+++ b/packages/sourcevision/src/analyzers/enrich-batch.ts
@@ -21,7 +21,7 @@ import {
   buildMetaPrompt,
 } from "./enrich-config.js";
 import type { PassConfig } from "./enrich-config.js";
-import { callClaude, ClaudeClientError } from "./claude-client.js";
+import { callClaude, resolveLightModel, ClaudeClientError } from "./claude-client.js";
 import { tryParseJSON, extractFindings, formatFileLabel, findPrevZone } from "./enrich-parsing.js";
 import { emptyAnalyzeTokenUsage, accumulateTokenUsage } from "./token-usage.js";
 import { startSpinner } from "../cli/output.js";
@@ -209,7 +209,13 @@ export async function enrichBatch(
 
     let callText: string;
     try {
-      const callResult = await callClaude(prompt);
+      // Pass 1 is naming-dominant ("LLM zone naming + initial observations"
+      // per enrich-config.ts) — Haiku does this accurately and ~3× faster
+      // than Sonnet. Pass 2+ is analytical (cross-zone relationships,
+      // anti-patterns, suggestions) and stays on the standard model so
+      // finding quality doesn't regress.
+      const callModel = passNumber === 1 ? resolveLightModel() : undefined;
+      const callResult = await callClaude(prompt, callModel);
       accumulateTokenUsage(batchTokenUsage, callResult.tokenUsage);
       callText = callResult.text;
     } catch (err) {

--- a/packages/sourcevision/src/analyzers/enrich-batch.ts
+++ b/packages/sourcevision/src/analyzers/enrich-batch.ts
@@ -339,7 +339,7 @@ const COMMENT_PREFIXES = ["///", "//!", "//", "/**", "/*", "*", "*/", "#", "#!",
  * Returns `null` when the file has no leading comment block, so callers can
  * skip emitting an empty header entry.
  */
-function extractFileHeader(absPath: string, maxLines = 40, maxChars = 800): string | null {
+function extractFileHeader(absPath: string, maxLines = 25, maxChars = 400): string | null {
   if (!existsSync(absPath)) return null;
   let content: string;
   try {
@@ -386,7 +386,7 @@ function extractFileHeader(absPath: string, maxLines = 40, maxChars = 800): stri
 function formatFileHeaders(
   files: string[],
   projectDir: string,
-  budgetBytes = 6000,
+  budgetBytes = 2500,
 ): string {
   const entries: string[] = [];
   let used = 0;

--- a/packages/sourcevision/src/analyzers/enrich-batch.ts
+++ b/packages/sourcevision/src/analyzers/enrich-batch.ts
@@ -5,7 +5,8 @@
  * Also handles meta-evaluation (pass 5+) which uses a single prompt.
  */
 
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
 import type {
   Zone,
   ZoneCrossing,
@@ -323,6 +324,89 @@ interface AttemptConfig {
 }
 
 /**
+ * Lines a leading-comment prefix is allowed to start with. Covers the
+ * documentation conventions of TS/JS/Swift/Rust/Python/Go/HTML/MD comment-only
+ * lines. A blank line is treated as part of the header so we don't truncate
+ * paragraph breaks inside a doc block.
+ */
+const COMMENT_PREFIXES = ["///", "//!", "//", "/**", "/*", "*", "*/", "#", "#!", "--", "<!--"];
+
+/**
+ * Extract the leading comment block of a file — i.e. the docstring the file's
+ * author wrote at the top to explain what it does. We stop at the first
+ * non-comment non-blank line and cap the output so we never blow the prompt.
+ *
+ * Returns `null` when the file has no leading comment block, so callers can
+ * skip emitting an empty header entry.
+ */
+function extractFileHeader(absPath: string, maxLines = 40, maxChars = 800): string | null {
+  if (!existsSync(absPath)) return null;
+  let content: string;
+  try {
+    content = readFileSync(absPath, "utf-8");
+  } catch {
+    return null;
+  }
+  const lines = content.split("\n", maxLines + 5);
+  const kept: string[] = [];
+  for (let i = 0; i < Math.min(lines.length, maxLines); i++) {
+    const raw = lines[i];
+    const trimmed = raw.trim();
+    // Skip a shebang on line 1.
+    if (i === 0 && trimmed.startsWith("#!")) {
+      kept.push(raw);
+      continue;
+    }
+    if (trimmed === "") {
+      // A blank line is acceptable as long as we've started a header — stop
+      // once we see a non-comment after that.
+      if (kept.length === 0) continue;
+      kept.push(raw);
+      continue;
+    }
+    if (!COMMENT_PREFIXES.some((p) => trimmed.startsWith(p))) {
+      break;
+    }
+    kept.push(raw);
+  }
+  // Trim trailing blanks.
+  while (kept.length > 0 && kept[kept.length - 1].trim() === "") kept.pop();
+  if (kept.length < 2) return null; // single-line headers are usually license/copyright, not useful context.
+  let joined = kept.join("\n");
+  if (joined.length > maxChars) joined = joined.slice(0, maxChars) + "\n  // …";
+  return joined;
+}
+
+/**
+ * Render a "File headers" section for the prompt — leading doc comments for
+ * the files in this batch. Bounds the total bytes so a giant batch can't
+ * inflate the prompt. Returns an empty string when no usable headers exist
+ * (so the prompt stays compact for projects without doc comments).
+ */
+function formatFileHeaders(
+  files: string[],
+  projectDir: string,
+  budgetBytes = 6000,
+): string {
+  const entries: string[] = [];
+  let used = 0;
+  for (const rel of files) {
+    if (used > budgetBytes) {
+      entries.push(`  - … (file-header budget exhausted; ${files.length - entries.length} files truncated)`);
+      break;
+    }
+    const header = extractFileHeader(join(projectDir, rel));
+    if (!header) continue;
+    const indented = header.split("\n").map((l) => `      ${l}`).join("\n");
+    const block = `  - ${rel}:\n${indented}`;
+    used += block.length;
+    entries.push(block);
+  }
+  if (entries.length === 0) return "";
+  return `\nFile headers (leading doc comments — treat these as authoritative about each file's purpose; DO NOT call a documented file "undocumented"):\n${entries.join("\n")}\n`;
+}
+
+/**
  * Render a "Project shape" section for the LLM prompt that grounds the model
  * in the repo's actual ecosystem. The model uses this to suppress
  * recommendations that don't fit (e.g. don't recommend MVVM coordinators on a
@@ -422,12 +506,16 @@ function buildFirstPassPrompt(
 ): string {
   const projectShape = projectProfile ? formatProjectShape(projectProfile) : "";
   if (config.maxFiles > 0) {
+    const sampledFiles: string[] = [];
     const zoneList = batchZones
       .map((z) => {
         const filesSample =
           z.files.length > config.maxFiles + 2
             ? [...z.files.slice(0, config.maxFiles), `... and ${z.files.length - config.maxFiles} more`]
             : z.files;
+        for (const f of filesSample) {
+          if (!f.startsWith("...") && !sampledFiles.includes(f)) sampledFiles.push(f);
+        }
         const entryLine = config.maxFiles >= 8
           ? `\n  entryPoints: ${z.entryPoints.map((f) => `"${f}"`).join(", ") || "none"}`
           : "";
@@ -435,12 +523,19 @@ function buildFirstPassPrompt(
       })
       .join("\n");
 
+    // Only include file-header excerpts on the full prompt; compact retries
+    // (config.maxFiles < 8) drop them to stay under context budgets.
+    const fileHeaders = projectProfile?.projectDir && config.maxFiles >= 8
+      ? formatFileHeaders(sampledFiles, projectProfile.projectDir)
+      : "";
+
     return `Analyze this codebase's zone structure. Each zone groups related files discovered by import-graph community detection.
 
 ${passConfig.focus}
 ${projectShape}
 Zones:
 ${zoneList}
+${fileHeaders}
 ${otherContext}
 ${priorNames}${hints ? `\nProject context from the developer:\n${hints}\n` : ""}
 Cross-zone imports:

--- a/packages/sourcevision/src/analyzers/enrich-config.ts
+++ b/packages/sourcevision/src/analyzers/enrich-config.ts
@@ -13,7 +13,12 @@ import type {
 
 // ── Batch mode constants ─────────────────────────────────────────────────────
 
-export const ZONES_PER_BATCH = 5;
+// Most small-to-medium projects produce 5–10 zones, so 7 lets the typical
+// case run in a single batch instead of two — combined with parallel batch
+// execution upstream, this halves enrichment wall-clock on those projects.
+// Set conservatively below the prompt-context ceiling so the full-prompt
+// attempt still fits comfortably with file headers + project shape.
+export const ZONES_PER_BATCH = 7;
 export const MAX_CONCURRENT_BATCHES = 1;
 
 // ── Per-zone mode constants ──────────────────────────────────────────────────

--- a/packages/sourcevision/src/analyzers/enrich-parsing.ts
+++ b/packages/sourcevision/src/analyzers/enrich-parsing.ts
@@ -95,6 +95,32 @@ export function classifyFinding(text: string): FindingCategory | undefined {
 // ── Finding extraction ───────────────────────────────────────────────────────
 
 /**
+ * True when a finding's text is phrased as a hypothesis the model never
+ * actually confirmed. These leak through despite the prompt guard
+ * (`prompt: "DO NOT surface 'if X then Y' findings"`) and are filtered here as
+ * a defensive backstop. We're deliberately strict — a finding that starts
+ * with "If…" is the model admitting it didn't probe.
+ */
+function isSpeculativeFinding(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  const head = t.slice(0, 120).toLowerCase();
+  // Leading conditional / hedging phrases.
+  const leaders = [
+    /^if\s+/,
+    /^when\s+(?:this|these|that|those)\s+/,
+    /^(should|might|may|could|potentially|possibly|perhaps)\s+/,
+    /^it\s+(may|might|could|appears|seems)\s+/,
+  ];
+  for (const re of leaders) {
+    if (re.test(head)) return true;
+  }
+  // Conditional clauses near the front that signal "I didn't verify".
+  if (/(^|\s)(if\s+(?:this|these|those|that)\s)/.test(head)) return true;
+  return false;
+}
+
+/**
  * Extract findings from AI response. Handles both new `findings` format
  * and legacy `insights` strings. Falls back to converting insights to findings.
  */
@@ -108,9 +134,14 @@ export function extractFindings(
   const validTypes: FindingType[] = ["observation", "pattern", "relationship", "anti-pattern", "suggestion"];
   const validSeverities = ["info", "warning", "critical"];
   const validCategories: FindingCategory[] = ["structural", "code", "documentation"];
+  let speculativeDropped = 0;
 
   const parseFinding = (f: any, fallbackScope: string) => {
     if (f && typeof f === "object" && typeof f.text === "string") {
+      if (isSpeculativeFinding(f.text)) {
+        speculativeDropped++;
+        return;
+      }
       const type: FindingType = validTypes.includes(f.type) ? f.type : defaultType;
       const explicitCategory: FindingCategory | undefined = validCategories.includes(f.category) ? f.category : undefined;
       const category = explicitCategory ?? classifyFinding(f.text);
@@ -181,6 +212,12 @@ export function extractFindings(
         }
       }
     }
+  }
+
+  if (speculativeDropped > 0) {
+    console.log(
+      `  [enrich] dropped ${speculativeDropped} speculative finding(s) (text began with "if X then…" or similar hedge)`,
+    );
   }
 
   return findings;

--- a/packages/sourcevision/src/analyzers/enrich.ts
+++ b/packages/sourcevision/src/analyzers/enrich.ts
@@ -180,37 +180,39 @@ export async function enrichZonesWithAI(
     console.log(`  [enrich] Processing ${zonesToEnrich.length} zones in ${batches.length} batches of up to ${ZONES_PER_BATCH}`);
   }
 
-  // 5. Process batches sequentially, feeding enriched names forward
-  const allBatchResults: BatchResult[] = [];
-  const enrichedNames = new Map<string, string>();
-  let authFailed = false;
-
-  for (let bi = 0; bi < batches.length; bi++) {
-    if (authFailed) break;
-
-    try {
-      const result = await enrichBatch(
-        batches[bi], zones, sortedCrossingsArr,
+  // 5. Process batches in parallel. The previous sequential loop fed an
+  //    `enrichedNames` map forward to dedupe zone names between batches —
+  //    that was only a HINT to the LLM, not a correctness requirement. We
+  //    fix any name collisions post-hoc in mergeZonesByName / dedupe steps,
+  //    so the parallel speedup (≈2× per pass with 2 batches, more for big
+  //    repos) is worth losing the cross-batch naming hint. Each batch is
+  //    still an independent LLM call. If ANY batch reports an auth error
+  //    we short-circuit the whole pass (no point sending another call to a
+  //    broken token).
+  const settled = await Promise.allSettled(
+    batches.map((batch, bi) =>
+      enrichBatch(
+        batch, zones, sortedCrossingsArr,
         passNumber, passConfig, previousZones, bi, batches.length,
-        enrichedNames, fileArchetypes, hints, projectProfile,
-      );
-      if (result && "authError" in result) {
-        authFailed = true;
-      } else if (result) {
-        allBatchResults.push(result);
+        new Map<string, string>(), fileArchetypes, hints, projectProfile,
+      ),
+    ),
+  );
 
-        // Track enriched names so subsequent batches can avoid duplicates
-        if (isFirstPass && Array.isArray(result.parsed.zones)) {
-          for (const z of result.parsed.zones) {
-            if (z?.algorithmicId && typeof z.name === "string") {
-              enrichedNames.set(z.algorithmicId, z.name);
-            }
-          }
-        }
-      }
-    } catch (err) {
-      console.error(`  [enrich] batch ${bi + 1} rejected:`, err instanceof Error ? err.message : err);
+  const allBatchResults: BatchResult[] = [];
+  let authFailed = false;
+  for (let bi = 0; bi < settled.length; bi++) {
+    const s = settled[bi];
+    if (s.status === "rejected") {
+      console.error(`  [enrich] batch ${bi + 1} rejected:`, s.reason instanceof Error ? s.reason.message : s.reason);
+      continue;
     }
+    const result = s.value;
+    if (result && "authError" in result) {
+      authFailed = true;
+      continue;
+    }
+    if (result) allBatchResults.push(result);
   }
 
   if (allBatchResults.length === 0) {

--- a/packages/sourcevision/src/analyzers/enrich.ts
+++ b/packages/sourcevision/src/analyzers/enrich.ts
@@ -130,15 +130,34 @@ export async function enrichZonesWithAI(
     };
   }
 
+  // 2a. Structural-zone bypass. A zone whose files are entirely non-source
+  //     (build scripts, assets, docs, config) has nothing for the LLM to
+  //     analyze — the zone description is the file list paraphrased and the
+  //     name comes from the directory. Templating these saves a meaningful
+  //     fraction of LLM cost on a typical repo (gotobed: 4 of 9 zones).
+  const templatedZones: Zone[] = [];
+  const llmCandidates: Zone[] = [];
+  const inventoryByPath = new Map(inventory.files.map((f) => [f.path, f]));
+  for (const zone of zones) {
+    if (isStructuralZone(zone, inventoryByPath)) {
+      templatedZones.push(applyStructuralTemplate(zone, inventoryByPath));
+    } else {
+      llmCandidates.push(zone);
+    }
+  }
+  if (templatedZones.length > 0) {
+    console.log(`  [enrich] ${templatedZones.length} structural zone(s) templated without LLM (build/asset/docs/config only)`);
+  }
+
   // 2. Per-zone content filtering: identify changed vs unchanged zones
   //    Only applies when we have previous data and per-zone content hashes.
   //    Unchanged zones preserve previous enrichment; only changed zones go to LLM.
-  let zonesToEnrich = zones;
+  let zonesToEnrich = llmCandidates;
   let unchangedZones: Zone[] = [];
 
   if (currentContentHashes && previousZones?.zoneContentHashes && prevEnrichPass > 0) {
     const changed: Zone[] = [];
-    for (const zone of zones) {
+    for (const zone of llmCandidates) {
       if (currentContentHashes[zone.id] !== previousZones.zoneContentHashes[zone.id]) {
         changed.push(zone);
       } else {
@@ -156,7 +175,7 @@ export async function enrichZonesWithAI(
       }
     }
     if (changed.length > 0 && unchangedZones.length > 0) {
-      console.log(`  [enrich] ${changed.length}/${zones.length} zones changed — skipping ${unchangedZones.length} unchanged`);
+      console.log(`  [enrich] ${changed.length}/${llmCandidates.length} zones changed — skipping ${unchangedZones.length} unchanged`);
       zonesToEnrich = changed;
     }
   }
@@ -218,22 +237,117 @@ export async function enrichZonesWithAI(
   if (allBatchResults.length === 0) {
     if (authFailed) {
       // auth error already logged upstream
-    } else if (batches.length === 0 && unchangedZones.length > 0) {
-      // All zones preserved from previous enrichment — return them
-      return { ...empty, zones: unchangedZones, pass: prevEnrichPass };
+    } else if (batches.length === 0 && (unchangedZones.length > 0 || templatedZones.length > 0)) {
+      // No LLM work to do — everything preserved or templated.
+      return { ...empty, zones: [...unchangedZones, ...templatedZones], pass: prevEnrichPass };
     } else if (batches.length > 0) {
       console.warn("  [enrich] All batches failed — using algorithmic names");
+    }
+    if (templatedZones.length > 0) {
+      return { ...empty, zones: templatedZones, pass: prevEnrichPass };
     }
     return empty;
   }
 
-  // 6. Aggregate and apply results, merging unchanged zones back in
+  // 6. Aggregate and apply results, merging unchanged + templated zones back in
   const agg = aggregateBatchResults(allBatchResults);
   const result = applyEnrichResults(zonesToEnrich, agg, passNumber, passConfig, previousZones);
   if (unchangedZones.length > 0) {
     result.zones = [...result.zones, ...unchangedZones];
   }
+  if (templatedZones.length > 0) {
+    result.zones = [...result.zones, ...templatedZones];
+  }
   return result;
+}
+
+// ── Structural-zone templating ───────────────────────────────────────────────
+
+/**
+ * A zone is "structural" if none of its files are source code — entirely
+ * build scripts / assets / docs / config / generated / other. There's nothing
+ * for the LLM to architecturally analyze; the zone description is the file
+ * list paraphrased and the name comes from the directory shape. Templating
+ * these saves a meaningful chunk of LLM cost.
+ */
+function isStructuralZone(
+  zone: Zone,
+  inventoryByPath: Map<string, { role: string }>,
+): boolean {
+  for (const f of zone.files) {
+    const entry = inventoryByPath.get(f);
+    if (entry?.role === "source") return false;
+  }
+  return zone.files.length > 0;
+}
+
+function applyStructuralTemplate(
+  zone: Zone,
+  inventoryByPath: Map<string, { role: string }>,
+): Zone {
+  // Tally roles. Whatever role dominates picks the noun.
+  const roleCounts = new Map<string, number>();
+  for (const f of zone.files) {
+    const r = inventoryByPath.get(f)?.role ?? "other";
+    roleCounts.set(r, (roleCounts.get(r) ?? 0) + 1);
+  }
+  const dominantRole = [...roleCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "other";
+
+  // Identify a top-level directory (the part before the first slash). All
+  // files at the repo root collapse to "root".
+  const topDirs = new Map<string, number>();
+  for (const f of zone.files) {
+    const slash = f.indexOf("/");
+    const top = slash === -1 ? "root" : f.slice(0, slash);
+    topDirs.set(top, (topDirs.get(top) ?? 0) + 1);
+  }
+  const topDir = [...topDirs.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
+
+  const titleCaseDir = topDir === "root"
+    ? "Project Root"
+    : topDir.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+  let name: string;
+  let descriptor: string;
+  switch (dominantRole) {
+    case "build":
+      name = topDir === "scripts" ? "Build & CI Scripts" : `${titleCaseDir} Scripts`;
+      descriptor = "Build, packaging, and CI scripts";
+      break;
+    case "asset":
+      name = topDir === "root" ? "Project Assets" : `${titleCaseDir} Assets`;
+      descriptor = "Bundle assets and resources";
+      break;
+    case "docs":
+      name = topDir === "docs" ? "Documentation Site" : `${titleCaseDir} Documentation`;
+      descriptor = "Documentation and static-site assets";
+      break;
+    case "config":
+      name = topDir === "root" ? "Project Root" : `${titleCaseDir} Config`;
+      descriptor = "Project configuration and manifest files";
+      break;
+    case "generated":
+      name = `${titleCaseDir} Generated`;
+      descriptor = "Machine-generated artifacts";
+      break;
+    default:
+      name = titleCaseDir || zone.name || zone.id;
+      descriptor = `Non-source files in ${topDir || "the project"}`;
+  }
+
+  // Short description that names a few representative files.
+  const sample = zone.files.slice(0, 3).map((f) => {
+    const idx = f.lastIndexOf("/");
+    return idx === -1 ? f : f.slice(idx + 1);
+  });
+  const more = zone.files.length > 3 ? ` (+${zone.files.length - 3} more)` : "";
+  const description = `${descriptor}: ${sample.join(", ")}${more}`;
+
+  return {
+    ...zone,
+    name,
+    description,
+  };
 }
 
 // ── Result application (private) ─────────────────────────────────────────────

--- a/packages/sourcevision/src/analyzers/enrich.ts
+++ b/packages/sourcevision/src/analyzers/enrich.ts
@@ -36,6 +36,7 @@ import type {
   ZoneCrossing,
   Zones,
   FindingType,
+  ProjectProfile,
 } from "../schema/index.js";
 
 import {
@@ -72,6 +73,7 @@ export async function enrichZonesWithAI(
   fileArchetypes?: Map<string, string | null>,
   currentContentHashes?: Record<string, string>,
   hints?: string,
+  projectProfile?: ProjectProfile,
 ): Promise<EnrichResult> {
   const prevEnrichPass = previousZones?.enrichmentPass ?? 0;
   const passNumber = prevEnrichPass + 1;
@@ -190,7 +192,7 @@ export async function enrichZonesWithAI(
       const result = await enrichBatch(
         batches[bi], zones, sortedCrossingsArr,
         passNumber, passConfig, previousZones, bi, batches.length,
-        enrichedNames, fileArchetypes, hints,
+        enrichedNames, fileArchetypes, hints, projectProfile,
       );
       if (result && "authError" in result) {
         authFailed = true;

--- a/packages/sourcevision/src/analyzers/imports.ts
+++ b/packages/sourcevision/src/analyzers/imports.ts
@@ -19,6 +19,7 @@ import { sortImports } from "../util/sort.js";
 import { detectCirculars } from "../util/merge.js";
 import { toPosix } from "../util/paths.js";
 import { extractGoImports, readGoModulePath } from "./go-imports.js";
+import { buildSwiftImportGraph } from "./swift-imports.js";
 import { readManifest } from "./manifest.js";
 import { getLanguageConfig, detectLanguages, mergeLanguageConfigs } from "../language/index.js";
 import type { LanguageConfig } from "../language/index.js";
@@ -27,6 +28,7 @@ import type { LanguageConfig } from "../language/index.js";
 
 const JS_TS_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
 const GO_EXTENSION = ".go";
+const SWIFT_EXTENSION = ".swift";
 const PROBE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
 
 // ── AST extraction ───────────────────────────────────────────────────────────
@@ -532,6 +534,49 @@ async function processGoFiles(
   }
 }
 
+/**
+ * Parse Swift files: extract `import X` (external modules) and infer
+ * file→file edges from symbol references. Same-module file relationships are
+ * implicit in Swift (no `import` between sibling files), so symbol references
+ * are the only way to reconstruct an internal graph short of a full compiler
+ * frontend. The result is heuristic but produces a usable graph for Louvain.
+ */
+async function processSwiftFiles(
+  files: Inventory["files"],
+  targetDir: string,
+  edgeMap: Map<string, ImportEdge>,
+  externalMap: Map<string, ExternalImport>,
+): Promise<void> {
+  if (files.length === 0) return;
+  const result = await buildSwiftImportGraph(files, targetDir);
+
+  for (const edge of result.edges) {
+    const key = `${edge.from}\0${edge.to}\0${edge.type}`;
+    const existing = edgeMap.get(key);
+    if (existing) {
+      edgeMap.set(key, {
+        ...existing,
+        symbols: Array.from(new Set([...existing.symbols, ...edge.symbols])),
+      });
+    } else {
+      edgeMap.set(key, edge);
+    }
+  }
+
+  for (const ext of result.external) {
+    const existing = externalMap.get(ext.package);
+    if (existing) {
+      externalMap.set(ext.package, {
+        package: ext.package,
+        importedBy: Array.from(new Set([...existing.importedBy, ...ext.importedBy])),
+        symbols: Array.from(new Set([...existing.symbols, ...ext.symbols])),
+      });
+    } else {
+      externalMap.set(ext.package, { ...ext });
+    }
+  }
+}
+
 /** Compute ImportsSummary statistics from collected edges and external packages. */
 function buildImportSummary(edges: ImportEdge[], external: ExternalImport[]): ImportsSummary {
   // Exclude type-only imports from mostImported: they don't create runtime
@@ -609,12 +654,14 @@ export async function analyzeImports(
     return true;
   });
 
-  // Partition into JS/TS and Go to prevent cross-language contamination
+  // Partition into JS/TS, Go, and Swift to prevent cross-language contamination
   const jsTsFiles = parseable.filter((f) => JS_TS_EXTENSIONS.has(extname(f.path).toLowerCase()));
   const goParseableFiles = parseable.filter((f) => extname(f.path).toLowerCase() === GO_EXTENSION);
+  const swiftParseableFiles = parseable.filter((f) => extname(f.path).toLowerCase() === SWIFT_EXTENSION);
 
   await processJsTsFiles(jsTsFiles, targetDir, resolver, edgeMap, externalMap);
   await processGoFiles(goParseableFiles, targetDir, goModulePath, edgeMap, externalMap);
+  await processSwiftFiles(swiftParseableFiles, targetDir, edgeMap, externalMap);
 
   // Incremental cleanup: remove packages whose importers were all changed
   if (canIncremental) {

--- a/packages/sourcevision/src/analyzers/imports.ts
+++ b/packages/sourcevision/src/analyzers/imports.ts
@@ -445,6 +445,51 @@ async function reExtractUnchangedExternals(
 }
 
 /** Parse JS/TS files and append edges and external imports to the provided maps. */
+/**
+ * Tokenize a JS/TS source file and count occurrences of each identifier-like
+ * token. Used to weight import edges by *actual usage* rather than just the
+ * import-statement binding list — a hub file that gets touched 30 times by a
+ * consumer is structurally more coupled than one mentioned once. This is a
+ * crude tokenizer (doesn't strip comments/strings); for the rare cases where
+ * an imported name shows up inside a string literal the noise washes out
+ * against the edge-weight cap applied below.
+ */
+function countIdentifierOccurrences(src: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  const tokenRe = /[A-Za-z_$][A-Za-z0-9_$]*/g;
+  let m: RegExpExecArray | null;
+  while ((m = tokenRe.exec(src)) !== null) {
+    counts.set(m[0], (counts.get(m[0]) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Cap a single edge's weight contribution so one hot connection can't
+ *  dominate Louvain — mirrors the Swift resolver's policy. */
+const JS_TS_EDGE_WEIGHT_CAP = 10;
+
+/**
+ * Compute the reference-count weight contribution of a single import's
+ * bindings. Subtracts 1 from each named symbol's count to discount the
+ * import statement's own mention of the name (it always appears once).
+ * Wildcard imports (`*`) and the synthetic `default` binding fall back to
+ * a baseline weight of 1 since we don't have a local alias for them.
+ */
+function importWeight(symbols: readonly string[], counts: Map<string, number>): number {
+  if (symbols.length === 0) return 1;
+  let total = 0;
+  let countedAny = false;
+  for (const s of symbols) {
+    if (s === "*" || s === "default") continue; // baseline elsewhere
+    const occ = counts.get(s);
+    if (occ === undefined) continue;
+    countedAny = true;
+    total += Math.max(0, occ - 1); // -1 for the import statement itself
+  }
+  if (!countedAny) return 1; // wildcards / unparseable bindings → baseline
+  return Math.max(1, total);
+}
+
 async function processJsTsFiles(
   files: Inventory["files"],
   targetDir: string,
@@ -460,17 +505,34 @@ async function processJsTsFiles(
       continue; // skip unreadable files
     }
 
+    const tokenCounts = countIdentifierOccurrences(sourceText);
+
     for (const raw of extractImports(sourceText, file.path)) {
       if (raw.specifier.startsWith("node:")) continue;
 
       const resolved = resolver.resolve(raw.specifier, file.path);
       if (resolved) {
+        const addWeight = Math.min(importWeight(raw.symbols, tokenCounts), JS_TS_EDGE_WEIGHT_CAP);
         const key = `${file.path}\0${resolved}\0${raw.type}`;
         const existing = edgeMap.get(key);
         if (existing) {
-          edgeMap.set(key, { ...existing, symbols: Array.from(new Set([...existing.symbols, ...raw.symbols])) });
+          const merged = Math.min(
+            (existing.weight ?? Math.max(existing.symbols.length, 1)) + addWeight,
+            JS_TS_EDGE_WEIGHT_CAP,
+          );
+          edgeMap.set(key, {
+            ...existing,
+            symbols: Array.from(new Set([...existing.symbols, ...raw.symbols])),
+            weight: merged,
+          });
         } else {
-          edgeMap.set(key, { from: file.path, to: resolved, type: raw.type, symbols: [...raw.symbols] });
+          edgeMap.set(key, {
+            from: file.path,
+            to: resolved,
+            type: raw.type,
+            symbols: [...raw.symbols],
+            weight: addWeight,
+          });
         }
       } else if (!raw.specifier.startsWith(".")) {
         // External package

--- a/packages/sourcevision/src/analyzers/louvain.ts
+++ b/packages/sourcevision/src/analyzers/louvain.ts
@@ -71,7 +71,12 @@ export function buildUndirectedGraph(edges: ImportEdge[]): UndirectedGraph {
   }
 
   for (const edge of edges) {
-    const weight = Math.max(edge.symbols.length, 1);
+    // Prefer the resolver-supplied weight when present (encodes raw
+    // reference count, capped to prevent hub-dominance). Fall back to
+    // the legacy "number of unique symbols" proxy when no weight is set
+    // — that path is still hit by TS/JS edges where the resolver only
+    // records unique symbols, not occurrence counts.
+    const weight = Math.max(edge.weight ?? edge.symbols.length, 1);
     addEdge(edge.from, edge.to, weight);
   }
 

--- a/packages/sourcevision/src/analyzers/project-profile.ts
+++ b/packages/sourcevision/src/analyzers/project-profile.ts
@@ -37,6 +37,7 @@ export function buildProjectProfile(
 
   return {
     schemaVersion: SCHEMA_VERSION,
+    projectDir,
     primaryLanguage,
     languages,
     frameworks,
@@ -45,6 +46,16 @@ export function buildProjectProfile(
     ciSurfaces,
     importGraphQuality,
   };
+}
+
+/**
+ * Return a profile suitable for serializing to `.sourcevision/project-profile.json`.
+ * Strips machine-specific paths (`projectDir`) so the on-disk file is portable.
+ */
+export function stripProjectProfileForDisk(p: ProjectProfile): Omit<ProjectProfile, "projectDir"> {
+  const { projectDir: _ignore, ...rest } = p;
+  void _ignore;
+  return rest;
 }
 
 // ── Languages ────────────────────────────────────────────────────────────────

--- a/packages/sourcevision/src/analyzers/project-profile.ts
+++ b/packages/sourcevision/src/analyzers/project-profile.ts
@@ -1,0 +1,290 @@
+/**
+ * Project profile detector.
+ *
+ * Inspects the project root for frameworks, release infrastructure, build
+ * surfaces, and CI surfaces. Runs once per analyze and writes the result to
+ * `.sourcevision/project-profile.json`. Downstream consumers (LLM finding
+ * prompt, dashboards, CONTEXT.md) read the profile to ground recommendations
+ * in the project's actual shape — e.g. suppress a "introduce a VERSION file"
+ * finding when `releaseInfrastructure` already includes release-please.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import type {
+  Inventory,
+  Imports,
+  ProjectProfile,
+  ReleaseInfrastructure,
+  ProjectSurface,
+} from "../schema/v1.js";
+
+const SCHEMA_VERSION = "1.0.0";
+
+/** Build the project profile from inventory, imports, and on-disk probes. */
+export function buildProjectProfile(
+  projectDir: string,
+  inventory: Inventory,
+  imports: Imports,
+): ProjectProfile {
+  const languages = collectLanguages(inventory);
+  const primaryLanguage = languages[0] ?? "unknown";
+  const frameworks = detectFrameworks(projectDir, inventory, primaryLanguage);
+  const releaseInfrastructure = detectReleaseInfrastructure(projectDir);
+  const buildSurfaces = detectBuildSurfaces(projectDir);
+  const ciSurfaces = detectCiSurfaces(projectDir);
+  const importGraphQuality = classifyImportGraph(inventory, imports);
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    primaryLanguage,
+    languages,
+    frameworks,
+    releaseInfrastructure,
+    buildSurfaces,
+    ciSurfaces,
+    importGraphQuality,
+  };
+}
+
+// ── Languages ────────────────────────────────────────────────────────────────
+
+function collectLanguages(inventory: Inventory): string[] {
+  const counts = new Map<string, number>();
+  for (const file of inventory.files) {
+    const lang = (file.language ?? "").toLowerCase();
+    if (!lang || lang === "unknown") continue;
+    counts.set(lang, (counts.get(lang) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([lang]) => lang);
+}
+
+// ── Import graph quality ─────────────────────────────────────────────────────
+
+function classifyImportGraph(
+  inventory: Inventory,
+  imports: Imports,
+): "rich" | "sparse" | "absent" {
+  const edgeCount = (imports.edges?.length ?? 0);
+  const fileCount = inventory.files.length;
+  if (edgeCount === 0) return "absent";
+  // A repo with <0.25 edges per source file has effectively no usable graph
+  // — Louvain will collapse it into proximity-driven noise.
+  const ratio = edgeCount / Math.max(1, fileCount);
+  if (ratio < 0.25) return "sparse";
+  return "rich";
+}
+
+// ── Frameworks ───────────────────────────────────────────────────────────────
+
+function detectFrameworks(
+  projectDir: string,
+  inventory: Inventory,
+  primaryLanguage: string,
+): string[] {
+  const found = new Set<string>();
+
+  // package.json deps (TS/JS)
+  const pkgPath = join(projectDir, "package.json");
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+      };
+      const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+      const has = (name: string) => Object.hasOwn(deps, name);
+      if (has("react")) found.add("react");
+      if (has("preact")) found.add("preact");
+      if (has("next")) found.add("nextjs");
+      if (has("@remix-run/react")) found.add("remix");
+      if (has("svelte")) found.add("svelte");
+      if (has("vue")) found.add("vue");
+      if (has("express")) found.add("express");
+      if (has("fastify")) found.add("fastify");
+      if (has("@nestjs/core")) found.add("nestjs");
+      if (has("vite")) found.add("vite");
+      if (has("vitest")) found.add("vitest");
+    } catch { /* ignore */ }
+  }
+
+  // Swift: Package.swift / .xcodeproj / .swift files importing SwiftUI/AppKit
+  if (primaryLanguage === "swift" || hasFileExt(inventory, ".swift")) {
+    if (existsSync(join(projectDir, "Package.swift"))) found.add("swiftpm");
+    if (anyDirEndsWith(projectDir, ".xcodeproj")) found.add("xcode");
+    const importLines = sampleSwiftImports(projectDir, inventory);
+    if (importLines.has("SwiftUI")) found.add("swiftui");
+    if (importLines.has("AppKit")) found.add("appkit");
+    if (importLines.has("UIKit")) found.add("uikit");
+    if (importLines.has("Combine")) found.add("combine");
+  }
+
+  // Rust
+  if (existsSync(join(projectDir, "Cargo.toml"))) found.add("cargo");
+
+  // Python
+  if (
+    existsSync(join(projectDir, "pyproject.toml")) ||
+    existsSync(join(projectDir, "requirements.txt"))
+  ) {
+    found.add("python");
+  }
+
+  // Go
+  if (existsSync(join(projectDir, "go.mod"))) found.add("go-modules");
+
+  return [...found].sort();
+}
+
+function hasFileExt(inventory: Inventory, ext: string): boolean {
+  return inventory.files.some((f) => f.path.endsWith(ext));
+}
+
+function anyDirEndsWith(projectDir: string, suffix: string): boolean {
+  try {
+    return readdirSync(projectDir).some(
+      (name) => name.endsWith(suffix) && safeIsDir(join(projectDir, name)),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function safeIsDir(path: string): boolean {
+  try { return statSync(path).isDirectory(); } catch { return false; }
+}
+
+/** Read up to 40 Swift files and collect distinct `import X` modules. */
+function sampleSwiftImports(projectDir: string, inventory: Inventory): Set<string> {
+  const imports = new Set<string>();
+  const swiftFiles = inventory.files
+    .filter((f) => f.path.endsWith(".swift"))
+    .slice(0, 40);
+  for (const f of swiftFiles) {
+    const abs = join(projectDir, f.path);
+    if (!existsSync(abs)) continue;
+    try {
+      const head = readFileSync(abs, "utf-8").split("\n", 60);
+      for (const line of head) {
+        const m = /^\s*import\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(line);
+        if (m) imports.add(m[1]);
+      }
+    } catch { /* ignore */ }
+  }
+  return imports;
+}
+
+// ── Release infrastructure ───────────────────────────────────────────────────
+
+function detectReleaseInfrastructure(projectDir: string): ReleaseInfrastructure[] {
+  const found: ReleaseInfrastructure[] = [];
+
+  const releasePleaseManifest = ".release-please-manifest.json";
+  if (existsSync(join(projectDir, releasePleaseManifest))) {
+    found.push({ kind: "release-please", evidence: releasePleaseManifest });
+  } else if (existsSync(join(projectDir, "release-please-config.json"))) {
+    found.push({ kind: "release-please", evidence: "release-please-config.json" });
+  }
+
+  if (existsSync(join(projectDir, ".changeset"))) {
+    found.push({ kind: "changesets", evidence: ".changeset" });
+  }
+
+  // package.json with a version field counts even without a publish pipeline.
+  const pkgPath = join(projectDir, "package.json");
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string };
+      if (pkg.version) found.push({ kind: "package.json", evidence: "package.json" });
+    } catch { /* ignore */ }
+  }
+
+  if (existsSync(join(projectDir, "Cargo.toml"))) {
+    found.push({ kind: "cargo", evidence: "Cargo.toml" });
+  }
+
+  const pyprojectPath = join(projectDir, "pyproject.toml");
+  if (existsSync(pyprojectPath)) {
+    found.push({ kind: "pyproject", evidence: "pyproject.toml" });
+  }
+
+  // git-tag-driven build scripts: any build/release script that calls
+  // `git describe` or `git tag`. We grep the heads of the obvious entry
+  // points instead of every file (cheap and false-positive-resistant).
+  const buildScripts = ["build.sh", "build-app.sh", "release.sh", "Makefile", "scripts/build.sh"];
+  for (const rel of buildScripts) {
+    const abs = join(projectDir, rel);
+    if (!existsSync(abs)) continue;
+    try {
+      const head = readFileSync(abs, "utf-8");
+      if (/git\s+describe|git\s+tag/.test(head)) {
+        found.push({ kind: "git-tag", evidence: rel });
+        break;
+      }
+    } catch { /* ignore */ }
+  }
+
+  // Plain VERSION/VERSION.txt file as last resort.
+  for (const cand of ["VERSION", "VERSION.txt"]) {
+    if (existsSync(join(projectDir, cand))) {
+      found.push({ kind: "version-file", evidence: cand });
+      break;
+    }
+  }
+
+  return found;
+}
+
+// ── Build surfaces ───────────────────────────────────────────────────────────
+
+function detectBuildSurfaces(projectDir: string): ProjectSurface[] {
+  const surfaces: ProjectSurface[] = [];
+  const candidates: Array<[string, string]> = [
+    ["Makefile", "Makefile"],
+    ["build.sh", "shell build script"],
+    ["build-app.sh", "shell build script"],
+    ["Package.swift", "swift package"],
+    ["Cargo.toml", "cargo package"],
+    ["pyproject.toml", "python package"],
+    ["go.mod", "go module"],
+    ["pnpm-workspace.yaml", "pnpm workspace"],
+  ];
+  for (const [path, kind] of candidates) {
+    if (existsSync(join(projectDir, path))) surfaces.push({ path, kind });
+  }
+  return surfaces;
+}
+
+// ── CI surfaces ──────────────────────────────────────────────────────────────
+
+function detectCiSurfaces(projectDir: string): ProjectSurface[] {
+  const surfaces: ProjectSurface[] = [];
+
+  const ghWorkflows = join(projectDir, ".github", "workflows");
+  if (existsSync(ghWorkflows) && safeIsDir(ghWorkflows)) {
+    try {
+      for (const entry of readdirSync(ghWorkflows)) {
+        if (/\.ya?ml$/.test(entry)) {
+          surfaces.push({
+            path: relative(projectDir, join(ghWorkflows, entry)),
+            kind: "GitHub Actions",
+          });
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  if (existsSync(join(projectDir, ".gitlab-ci.yml"))) {
+    surfaces.push({ path: ".gitlab-ci.yml", kind: "GitLab CI" });
+  }
+  if (existsSync(join(projectDir, "bitbucket-pipelines.yml"))) {
+    surfaces.push({ path: "bitbucket-pipelines.yml", kind: "Bitbucket Pipelines" });
+  }
+  if (existsSync(join(projectDir, ".circleci", "config.yml"))) {
+    surfaces.push({ path: ".circleci/config.yml", kind: "CircleCI" });
+  }
+
+  return surfaces;
+}

--- a/packages/sourcevision/src/analyzers/swift-imports.ts
+++ b/packages/sourcevision/src/analyzers/swift-imports.ts
@@ -163,20 +163,26 @@ export function extractSwiftDeclarations(src: string): string[] {
 // own declarations avoids self-loops.
 
 /**
- * Find which of `symbols` are referenced in `src`. Caller is expected to
- * pre-strip the file's own declarations so a file that declares Foo and uses
- * it elsewhere doesn't self-loop.
+ * Find which of `symbols` are referenced in `src`, returning a per-symbol
+ * occurrence count. The count drives edge-weight downstream: a file that
+ * touches `AppEnvironment` twenty times is structurally more coupled to it
+ * than a file that mentions it once. Caller is expected to pre-strip the
+ * file's own declarations so a file that declares Foo and uses it elsewhere
+ * doesn't self-loop.
  */
-export function findSymbolReferences(src: string, symbols: ReadonlySet<string>): Set<string> {
+export function findSymbolReferences(
+  src: string,
+  symbols: ReadonlySet<string>,
+): Map<string, number> {
   const cleaned = stripCommentsAndStrings(src);
-  const hits = new Set<string>();
+  const hits = new Map<string, number>();
   if (symbols.size === 0) return hits;
-  // Tokenize identifiers and lookup. Tokenizer is cheap and avoids the
-  // RegExp-per-symbol pathology.
   const tokenRe = /[A-Z][A-Za-z0-9_]*/g;
   let m: RegExpExecArray | null;
   while ((m = tokenRe.exec(cleaned)) !== null) {
-    if (symbols.has(m[0])) hits.add(m[0]);
+    if (symbols.has(m[0])) {
+      hits.set(m[0], (hits.get(m[0]) ?? 0) + 1);
+    }
   }
   return hits;
 }
@@ -245,7 +251,7 @@ export async function buildSwiftImportGraph(
       : new Set([...allSymbols].filter((s) => !own.has(s)));
 
     const refs = findSymbolReferences(src, candidates);
-    for (const sym of refs) {
+    for (const [sym, count] of refs) {
       const declaringFiles = declIndex.get(sym);
       if (!declaringFiles) continue;
       for (const to of declaringFiles) {
@@ -253,18 +259,36 @@ export async function buildSwiftImportGraph(
         const key = `${path}\0${to}\0static`;
         const existing = edgeMap.get(key);
         if (existing) {
-          if (!existing.symbols.includes(sym)) {
-            edgeMap.set(key, { ...existing, symbols: [...existing.symbols, sym] });
-          }
+          const nextSymbols = existing.symbols.includes(sym)
+            ? existing.symbols
+            : [...existing.symbols, sym];
+          edgeMap.set(key, {
+            ...existing,
+            symbols: nextSymbols,
+            weight: (existing.weight ?? 0) + count,
+          });
         } else {
           edgeMap.set(key, {
             from: path,
             to,
             type: "static" as ImportType,
             symbols: [sym],
+            weight: count,
           });
         }
       }
+    }
+  }
+
+  // Cap each edge's weight so a single very-hot connection can't dominate
+  // Louvain. AppEnvironment-style composition-root files often have a few
+  // call-sites that reference them ~50 times — that should still beat a
+  // one-mention edge but not by 50×, or it pulls the file into whichever
+  // cluster has the highest single reference count.
+  const EDGE_WEIGHT_CAP = 10;
+  for (const [key, edge] of edgeMap) {
+    if (edge.weight !== undefined && edge.weight > EDGE_WEIGHT_CAP) {
+      edgeMap.set(key, { ...edge, weight: EDGE_WEIGHT_CAP });
     }
   }
 

--- a/packages/sourcevision/src/analyzers/swift-imports.ts
+++ b/packages/sourcevision/src/analyzers/swift-imports.ts
@@ -1,0 +1,275 @@
+/**
+ * Swift import + symbol-reference resolver.
+ *
+ * Swift's `import X` references a MODULE (Foundation, SwiftUI, AppKit, a SPM
+ * dependency), not a file — files in the same module reference each other
+ * implicitly with no import statement. A literal "Swift import parser" would
+ * therefore produce zero internal edges and leave zone detection guessing
+ * from file-tree proximity.
+ *
+ * This analyzer is two passes:
+ *   1. Top-of-file `import X` → external imports. Used for framework
+ *      detection (SwiftUI vs AppKit vs UIKit) and stdlib classification.
+ *   2. Symbol declarations (`class/struct/enum/protocol/actor/extension`)
+ *      across the project build a symbol → file index. Each file is then
+ *      scanned for references to those declared symbols and yields one
+ *      internal edge per referenced symbol's declaring file.
+ *
+ * This gives sourcevision a real, if heuristic, Swift file→file import
+ * graph — `importGraphQuality` flips from "absent" to "rich" on a typical
+ * SwiftUI app and zone detection (Louvain) produces meaningful zones with
+ * actual cohesion rather than proximity-driven noise.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ImportEdge, ImportType, ExternalImport } from "../schema/index.js";
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+export interface SwiftImportResult {
+  /** Internal edges built from symbol references (file → file). */
+  edges: ImportEdge[];
+  /** External module imports (`import X` statements). */
+  external: ExternalImport[];
+}
+
+// ── Apple stdlib / first-party framework list ────────────────────────────────
+//
+// Anything outside this set imported via `import X` is treated as third-party.
+// Not exhaustive — covers what a typical macOS/iOS app uses. Easy to extend.
+
+const APPLE_STDLIB_MODULES: ReadonlySet<string> = new Set([
+  // Core
+  "Foundation", "Swift", "ObjectiveC", "Dispatch", "OSLog", "os",
+  // UI
+  "SwiftUI", "AppKit", "UIKit", "WatchKit", "TVUIKit",
+  // System frameworks
+  "Combine", "CoreData", "CoreGraphics", "CoreText", "CoreImage", "CoreLocation",
+  "CoreMedia", "CoreAudio", "CoreBluetooth", "CoreMotion", "CoreML", "CoreTelephony",
+  "Accelerate", "Accessibility", "AVFoundation", "AVKit",
+  "Network", "NetworkExtension", "AppIntents", "Intents", "IntentsUI",
+  "MediaPlayer", "MetricKit", "WebKit",
+  "MapKit", "Charts", "Photos", "PhotosUI", "Vision", "VisionKit",
+  "QuickLook", "QuickLookUI", "QuickLookThumbnailing",
+  "Security", "LocalAuthentication", "AuthenticationServices",
+  "CryptoKit", "DeviceCheck", "AdSupport", "ARKit", "SceneKit", "SpriteKit",
+  "RealityKit", "ModelIO", "GameKit", "GameplayKit",
+  "Speech", "NaturalLanguage", "SoundAnalysis",
+  "UserNotifications", "UserNotificationsUI",
+  "StoreKit", "CloudKit", "PassKit", "Contacts", "ContactsUI",
+  "EventKit", "EventKitUI", "HomeKit", "HealthKit", "BackgroundTasks",
+  "WidgetKit", "ActivityKit",
+  // Testing
+  "XCTest", "Testing",
+  // Catalyst / Multi-platform
+  "TabularData",
+]);
+
+function classifyImport(modulePath: string): "stdlib" | "third-party" {
+  return APPLE_STDLIB_MODULES.has(modulePath) ? "stdlib" : "third-party";
+}
+
+// ── Comment + string stripping ───────────────────────────────────────────────
+//
+// We strip line and block comments and double-quoted strings before scanning
+// for declarations and references. Without this, every `// uses SchedulerEngine`
+// comment would be parsed as a real reference. Multi-line `"""` strings are
+// also stripped. We keep it simple — no full lexer — but it handles the cases
+// that drive false positives in practice.
+
+function stripCommentsAndStrings(src: string): string {
+  let out = "";
+  let i = 0;
+  const len = src.length;
+  while (i < len) {
+    const c = src[i];
+    const next = src[i + 1];
+    // Line comment
+    if (c === "/" && next === "/") {
+      const eol = src.indexOf("\n", i);
+      out += src.slice(i, i + 2); // keep "//" so line lengths roughly match for line-based scanners
+      i = eol === -1 ? len : eol;
+      continue;
+    }
+    // Block comment
+    if (c === "/" && next === "*") {
+      const end = src.indexOf("*/", i + 2);
+      i = end === -1 ? len : end + 2;
+      continue;
+    }
+    // Multi-line string `"""..."""`
+    if (c === '"' && next === '"' && src[i + 2] === '"') {
+      const end = src.indexOf('"""', i + 3);
+      i = end === -1 ? len : end + 3;
+      continue;
+    }
+    // Single-line string `"..."` with escape handling
+    if (c === '"') {
+      i++;
+      while (i < len) {
+        const ch = src[i];
+        if (ch === "\\") { i += 2; continue; }
+        if (ch === '"' || ch === "\n") { i++; break; }
+        i++;
+      }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+// ── Import-line extraction ───────────────────────────────────────────────────
+
+const IMPORT_RE = /^\s*import\s+(?:[a-z]+\s+)?([A-Za-z_][A-Za-z0-9_]*)(?:\.[A-Za-z_][A-Za-z0-9_.]*)?\s*$/;
+
+/** Extract `import X` modules from a Swift source. Returns module names. */
+export function extractSwiftImportModules(src: string): string[] {
+  const cleaned = stripCommentsAndStrings(src);
+  const out: string[] = [];
+  for (const line of cleaned.split("\n")) {
+    const m = IMPORT_RE.exec(line);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+// ── Declaration extraction ───────────────────────────────────────────────────
+//
+// Swift declarations that introduce a referenceable type name. `extension`
+// is included so that `extension Foo { … }` produces a reference back to the
+// file that originally declared Foo (handled at edge-build time).
+
+const DECL_RE = /\b(?:class|struct|enum|protocol|actor|extension|typealias)\s+([A-Z][A-Za-z0-9_]*)/g;
+
+/** Extract declared top-level symbol names from a Swift source. */
+export function extractSwiftDeclarations(src: string): string[] {
+  const cleaned = stripCommentsAndStrings(src);
+  const out = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = DECL_RE.exec(cleaned)) !== null) {
+    out.add(m[1]);
+  }
+  return [...out];
+}
+
+// ── Reference extraction ─────────────────────────────────────────────────────
+//
+// We don't try to parse Swift expressions. Instead: after stripping comments
+// and strings, every word-boundary occurrence of a known declared symbol that
+// is NOT the declaration itself counts as a reference. Skipping the file's
+// own declarations avoids self-loops.
+
+/**
+ * Find which of `symbols` are referenced in `src`. Caller is expected to
+ * pre-strip the file's own declarations so a file that declares Foo and uses
+ * it elsewhere doesn't self-loop.
+ */
+export function findSymbolReferences(src: string, symbols: ReadonlySet<string>): Set<string> {
+  const cleaned = stripCommentsAndStrings(src);
+  const hits = new Set<string>();
+  if (symbols.size === 0) return hits;
+  // Tokenize identifiers and lookup. Tokenizer is cheap and avoids the
+  // RegExp-per-symbol pathology.
+  const tokenRe = /[A-Z][A-Za-z0-9_]*/g;
+  let m: RegExpExecArray | null;
+  while ((m = tokenRe.exec(cleaned)) !== null) {
+    if (symbols.has(m[0])) hits.add(m[0]);
+  }
+  return hits;
+}
+
+// ── Pipeline ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build the full Swift import graph for a set of Swift files. Two-pass:
+ * collect declarations first, then walk files and emit edges.
+ *
+ * `targetDir` is the absolute project root used to resolve relative
+ * `filePath`s to disk reads.
+ */
+export async function buildSwiftImportGraph(
+  swiftFiles: Array<{ path: string }>,
+  targetDir: string,
+): Promise<SwiftImportResult> {
+  // Pre-read all source contents once; both passes need them.
+  const sources = new Map<string, string>();
+  for (const f of swiftFiles) {
+    try {
+      const text = await readFile(join(targetDir, f.path), "utf-8");
+      sources.set(f.path, text);
+    } catch {
+      // Skip unreadable files — they just won't contribute.
+    }
+  }
+
+  // Pass 1: collect declarations and external imports.
+  /** symbol → declaring file paths (multiple if name collides across files). */
+  const declIndex = new Map<string, string[]>();
+  /** declared symbols PER file (used to exclude self-references in pass 2). */
+  const ownDecls = new Map<string, Set<string>>();
+  const externalMap = new Map<string, ExternalImport>();
+
+  for (const [path, src] of sources) {
+    const decls = extractSwiftDeclarations(src);
+    ownDecls.set(path, new Set(decls));
+    for (const sym of decls) {
+      const arr = declIndex.get(sym) ?? [];
+      arr.push(path);
+      declIndex.set(sym, arr);
+    }
+    for (const mod of extractSwiftImportModules(src)) {
+      const kind = classifyImport(mod);
+      const pkg = kind === "stdlib" ? `stdlib:${mod}` : mod;
+      const existing = externalMap.get(pkg);
+      if (existing) {
+        if (!existing.importedBy.includes(path)) existing.importedBy.push(path);
+      } else {
+        externalMap.set(pkg, { package: pkg, importedBy: [path], symbols: ["*"] });
+      }
+    }
+  }
+
+  // Pass 2: walk each file, find references to declared symbols, emit edges.
+  const edgeMap = new Map<string, ImportEdge>();
+  const allSymbols = new Set(declIndex.keys());
+
+  for (const [path, src] of sources) {
+    const own = ownDecls.get(path) ?? new Set<string>();
+    // Subtract this file's own declarations from the lookup set so a file's
+    // internal use of a symbol it owns isn't counted as an external edge.
+    const candidates = own.size === 0
+      ? allSymbols
+      : new Set([...allSymbols].filter((s) => !own.has(s)));
+
+    const refs = findSymbolReferences(src, candidates);
+    for (const sym of refs) {
+      const declaringFiles = declIndex.get(sym);
+      if (!declaringFiles) continue;
+      for (const to of declaringFiles) {
+        if (to === path) continue;
+        const key = `${path}\0${to}\0static`;
+        const existing = edgeMap.get(key);
+        if (existing) {
+          if (!existing.symbols.includes(sym)) {
+            edgeMap.set(key, { ...existing, symbols: [...existing.symbols, sym] });
+          }
+        } else {
+          edgeMap.set(key, {
+            from: path,
+            to,
+            type: "static" as ImportType,
+            symbols: [sym],
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    edges: [...edgeMap.values()],
+    external: [...externalMap.values()],
+  };
+}

--- a/packages/sourcevision/src/analyzers/zones.ts
+++ b/packages/sourcevision/src/analyzers/zones.ts
@@ -922,11 +922,65 @@ function assertAnchorZones(
 
 // ── Recursive subdivision ────────────────────────────────────────────────────
 
-/** Zones with more than this many files are subdivided recursively. */
-export const SUBDIVISION_THRESHOLD = 50;
+/**
+ * Absolute floor for the subdivision threshold. A zone with fewer than this
+ * many files is never subdivided regardless of project size — the noise
+ * floor below which sub-zoning is more confusing than useful.
+ */
+export const SUBDIVISION_THRESHOLD_MIN = 12;
+
+/**
+ * Project-relative subdivision trigger. Any zone exceeding this fraction of
+ * total project files is considered "likely multiple concerns" and gets
+ * recursively split — independent of its measured cohesion (a 29-file zone
+ * with cohesion 0.79 routinely contains 3+ architectural roles glued
+ * together by a few shared types).
+ */
+export const SUBDIVISION_THRESHOLD_PCT = 0.15;
+
+/**
+ * Compute the subdivision threshold for a project of `totalFiles` files.
+ * Caller passes `inventory.files.length` — we use the larger of the absolute
+ * floor and the project-relative fraction so small repos still subdivide
+ * meaningful blobs and large repos don't fragment into noise.
+ *
+ * Legacy export `SUBDIVISION_THRESHOLD` kept as the absolute floor so any
+ * external consumer pinning to the constant still gets reasonable behavior.
+ */
+export function subdivisionThreshold(totalFiles: number): number {
+  return Math.max(SUBDIVISION_THRESHOLD_MIN, Math.floor(totalFiles * SUBDIVISION_THRESHOLD_PCT));
+}
+
+/** @deprecated use {@link subdivisionThreshold}(totalFiles) — kept for back-compat */
+export const SUBDIVISION_THRESHOLD = SUBDIVISION_THRESHOLD_MIN;
 
 /** Maximum recursion depth for subdivision to prevent infinite loops. */
 export const MAX_SUBDIVISION_DEPTH = 3;
+
+/**
+ * Map a test file path to its community ID. Groups test files by their
+ * top-level Tests/<suite>/ prefix so projects with multiple test targets
+ * (e.g. `Tests/GoToBedCoreTests`, `Tests/GoToBedTests`) get one zone per
+ * suite. Files not under a Tests/<suite>/ path fall back to a single
+ * "tests" community.
+ */
+export function deriveTestSuiteCommunity(filePath: string): string {
+  const segments = filePath.split("/");
+  // Look for a "Tests" or "tests" or "test" segment near the top of the path.
+  for (let i = 0; i < segments.length - 1; i++) {
+    const lc = segments[i].toLowerCase();
+    if (lc === "tests" || lc === "test") {
+      const suite = segments[i + 1];
+      // Only use the suite if it's itself a directory (not the test file
+      // sitting directly in Tests/) — otherwise lump under generic tests.
+      if (i + 2 < segments.length) {
+        return `tests:${segments[i]}/${suite}`;
+      }
+      return `tests:${segments[i]}`;
+    }
+  }
+  return "tests";
+}
 
 /**
  * Subdivide a large zone by running the full zone pipeline on its internal
@@ -943,8 +997,13 @@ export function subdivideZone(
   testFiles: Set<string> = new Set(),
   depth: number = 0
 ): Zone[] {
-  // Don't subdivide small zones or if we've hit max depth
-  if (zone.files.length < SUBDIVISION_THRESHOLD || depth >= MAX_SUBDIVISION_DEPTH) {
+  // Don't subdivide small zones or if we've hit max depth. The threshold is
+  // project-size-relative — a 29-file zone in a 111-file project is 26 % of
+  // the codebase and almost certainly contains multiple architectural roles
+  // glued by shared types; under the legacy flat 50-file gate, that zone
+  // would never have been touched.
+  const threshold = subdivisionThreshold(inventory.files.length);
+  if (zone.files.length < threshold || depth >= MAX_SUBDIVISION_DEPTH) {
     return [];
   }
 
@@ -1649,8 +1708,23 @@ function buildZonesFromCommunities(
     .map(([comm, members]) => [comm, members.sort()] as const)
     .sort(([, a], [, b]) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
 
-  for (const [, members] of sortedCommunities) {
-    let id = deriveZoneId(members, parentId);
+  for (const [communityId, members] of sortedCommunities) {
+    // Quarantined-test communities have IDs of the form `tests:<suite>` from
+    // deriveTestSuiteCommunity. The default `deriveZoneId` skips "tests" as
+    // a generic segment, so a community whose files all live in a test
+    // directory would collide with the production zone that shares the
+    // adjacent segment (e.g. `tests/core/` derives to "core" which
+    // collides with `src/core/`). Honor the community ID directly so test
+    // zones get a stable test-flavored id (`tests-<suite>`).
+    let id: string;
+    if (communityId.startsWith("tests:")) {
+      const suiteRaw = communityId.slice("tests:".length);
+      const suite = suiteRaw.split("/").pop() ?? suiteRaw;
+      const normalized = suite.toLowerCase().replace(/_/g, "-").replace(/^-+|-+$/g, "");
+      id = normalized ? `tests-${normalized}` : "tests";
+    } else {
+      id = deriveZoneId(members, parentId);
+    }
     if (usedIds.has(id)) {
       const disambiguated = disambiguateZoneId(id, members, parentId);
       if (disambiguated !== id && !usedIds.has(disambiguated)) {
@@ -2258,31 +2332,87 @@ export function runZonePipeline(options: ZonePipelineOptions): ZonePipelineResul
     addStabilityEdges(graph, importOnlyGraph, previousZoneAssignment, stabilityWeight);
   }
 
+  // ── Quarantine tests from production partitioning (selective) ──
+  // Tests routinely import production code heavily — `XYZTests.swift`
+  // touches every type in `XYZ.swift`, which makes Louvain glue tests to
+  // their subjects' zones. We strip those tests from the Louvain input and
+  // drop them into their own per-suite zone(s).
+  //
+  // BUT: only when the tests live in a TEST-ONLY directory. Go convention
+  // puts `user_test.go` next to `user.go` inside `internal/handler/`; that
+  // package boundary IS the architectural unit and the test belongs with
+  // it. So a test file whose directory also contains production files is
+  // a "colocated" test and stays with its package.
+  const productionDirs = new Set<string>();
+  for (const f of scopeFiles) {
+    if (testFiles.has(f)) continue;
+    const slash = f.lastIndexOf("/");
+    productionDirs.add(slash === -1 ? "" : f.slice(0, slash));
+  }
+  const quarantineTests = new Set<string>();
+  for (const t of testFiles) {
+    if (!scopeFileSet.has(t)) continue;
+    const slash = t.lastIndexOf("/");
+    const dir = slash === -1 ? "" : t.slice(0, slash);
+    if (!productionDirs.has(dir)) quarantineTests.add(t);
+  }
+  // Filter AFTER proximity + stability edges are added so production files
+  // without imports still appear in productionGraph via proximity links.
+  const productionGraph: Map<string, Map<string, number>> = new Map();
+  for (const [node, neighbors] of graph) {
+    if (quarantineTests.has(node)) continue;
+    const filtered = new Map<string, number>();
+    for (const [n, w] of neighbors) {
+      if (quarantineTests.has(n)) continue;
+      filtered.set(n, w);
+    }
+    productionGraph.set(node, filtered);
+  }
+  // Ensure non-quarantined scope files with NO edges at all still get
+  // partitioned (would otherwise be dropped on the floor by Louvain and
+  // re-collected as "unzoned" with no chance to land in a real zone).
+  for (const f of scopeFiles) {
+    if (quarantineTests.has(f)) continue;
+    if (!productionGraph.has(f)) productionGraph.set(f, new Map());
+  }
+
   // ── Scale maxZones by file count ──
   // Small packages shouldn't fragment into many zones. Scale from 3 (≤36 files)
   // up to the configured cap (default 30 at 360+ files).
   // Also ensure we allow enough zones for the size policy to work —
   // if maxZonePercent limits zone size, we need at least ceil(n/maxSize) zones.
-  const graphNodeCount = graph.size;
+  // graphNodeCount reflects the partitioning surface (production only) so
+  // maxZoneSize stays relative to the code that's actually being clustered.
+  const graphNodeCount = productionGraph.size;
   const scaledByCount = Math.max(3, Math.floor(graphNodeCount / 12));
   const maxPct = Math.max(1, Math.min(100, maxZonePercent));
   const maxZoneSize = Math.max(3, Math.ceil(graphNodeCount * maxPct / 100));
   const minForSizePolicy = maxPct < 100 ? Math.ceil(graphNodeCount / maxZoneSize) : 0;
   const scaledMaxZones = Math.min(maxZones, Math.max(scaledByCount, minForSizePolicy));
 
-  // ── Louvain community detection ──
+  // ── Louvain community detection (production only) ──
   const smallZoneMergeLog: MergeLogEntry[] = [];
-  let community = louvainPhase1(graph, 100, 1.0, previousZoneAssignment);
-  community = mergeBidirectionalCoupling(community, graph);
-  community = mergeSmallCommunities(community, graph, smallZoneMergeThreshold, smallZoneMergeLog);
-  community = mergeSatelliteCommunities(community, graph);
-  community = capZoneCount(community, graph, scaledMaxZones);
+  let community = louvainPhase1(productionGraph, 100, 1.0, previousZoneAssignment);
+  community = mergeBidirectionalCoupling(community, productionGraph);
+  community = mergeSmallCommunities(community, productionGraph, smallZoneMergeThreshold, smallZoneMergeLog);
+  community = mergeSatelliteCommunities(community, productionGraph);
+  community = capZoneCount(community, productionGraph, scaledMaxZones);
 
-  // ── Split oversized communities ──
-  community = splitLargeCommunities(community, graph, maxZoneSize);
+  // ── Split oversized communities (production only) ──
+  community = splitLargeCommunities(community, productionGraph, maxZoneSize);
 
   mergeSameIdCommunities(community, maxPct < 100 ? maxZoneSize : undefined);
-  community = capZoneCount(community, graph, scaledMaxZones);  // re-cap after split
+  community = capZoneCount(community, productionGraph, scaledMaxZones);  // re-cap after split
+
+  // ── Drop quarantined tests into their own per-suite zones ──
+  // Group quarantined test files by their top-level Tests/<suite>/ prefix
+  // so multi-target projects (e.g. GoToBedCoreTests + GoToBedTests) get a
+  // zone per suite rather than one mega-tests zone. Colocated tests
+  // (`internal/foo/*_test.go`) stayed in productionGraph and are already
+  // partitioned alongside their package.
+  for (const testFile of quarantineTests) {
+    community.set(testFile, deriveTestSuiteCommunity(testFile));
+  }
 
   // ── Build zones from communities ──
   const { zones, filenameBasedZoneIds } = buildZonesFromCommunities(

--- a/packages/sourcevision/src/analyzers/zones.ts
+++ b/packages/sourcevision/src/analyzers/zones.ts
@@ -31,6 +31,7 @@ import type {
   Finding,
   AnalyzeTokenUsage,
   SubAnalysisRef,
+  ProjectProfile,
 } from "../schema/index.js";
 import type { SubAnalysis } from "./workspace.js";
 import {
@@ -1814,6 +1815,7 @@ async function applyEnrichment(
   fileArchetypes?: Map<string, string | null>,
   currentContentHashes?: Record<string, string>,
   hints?: string,
+  projectProfile?: ProjectProfile,
 ): Promise<EnrichmentResult> {
   let finalZones = expandedZones;
   let aiZoneInsights = new Map<string, string[]>();
@@ -1856,7 +1858,7 @@ async function applyEnrichment(
     } else {
       const result = await enrichZonesWithAI(
         expandedZones, preCrossings, inventory, imports, validPrevious, fileArchetypes,
-        currentContentHashes, hints,
+        currentContentHashes, hints, projectProfile,
       );
       finalZones = result.zones;
       aiZoneInsights = result.newZoneInsights;
@@ -2659,6 +2661,12 @@ export async function analyzeZones(
      * Used by --full enrichment passes to avoid non-deterministic re-partitioning.
      */
     reuseStructure?: boolean;
+    /**
+     * Detected project profile (frameworks, release infra, import-graph quality).
+     * Forwarded to the AI enrichment prompt so the LLM can suppress
+     * recommendations that contradict the project's actual shape.
+     */
+    projectProfile?: ProjectProfile;
   }
 ): Promise<AnalyzeZonesResult> {
   const enrich = options?.enrich ?? true;
@@ -2757,7 +2765,7 @@ export async function analyzeZones(
   // ── AI enrichment or preserve previous ──
   const enrichResult = await applyEnrichment(
     expandedZones, imports, inventory, validPrevious, enrich, perZone, options?.fileArchetypes,
-    zoneContentHashes, options?.hints,
+    zoneContentHashes, options?.hints, options?.projectProfile,
   );
   const { finalZones: enrichedZones, aiZoneInsights, aiGlobalInsights, aiFindings,
     enrichmentPass, metaUpdatedFindings, enrichTokenUsage } = enrichResult;

--- a/packages/sourcevision/src/cli/commands/analyze-phases.ts
+++ b/packages/sourcevision/src/cli/commands/analyze-phases.ts
@@ -54,6 +54,7 @@ import type {
 } from "../sourcevision-core.js";
 import { info } from "../output.js";
 import { bold, cyan, dim, yellow, green, red, loadProjectOverrides } from "@n-dx/llm-client";
+import { buildProjectProfile } from "../../analyzers/project-profile.js";
 
 // ── Shared context passed between phases ─────────────────────────────
 
@@ -332,11 +333,22 @@ export async function runZonesPhase(ctx: AnalyzeContext, extraArgs: string[]): P
       info(`  ${dim(`Using zone merge threshold ${smallZoneMergeThreshold} from .n-dx.json`)}`);
     }
 
+    // Detect the project profile (frameworks, release infra, import-graph
+    // quality) and persist it now so it is available to the enrichment prompt
+    // AND to downstream consumers (CONTEXT.md, dashboards) for the rest of
+    // this analyze run. Writing in the output stage as well is idempotent.
+    const projectProfile = buildProjectProfile(ctx.absDir, inventory, importsData);
+    writeFileSync(
+      join(ctx.svDir, DATA_FILES.projectProfile),
+      toCanonicalJSON(projectProfile),
+    );
+
     let zonesResult = await analyzeZones(inventory, importsData, {
       enrich, previousZones, perZone, subAnalyses, fileArchetypes, onReset, hints,
       zonePins: pinCount > 0 ? zonePins : undefined,
       zoneAnchors: zoneAnchors.length > 0 ? zoneAnchors : undefined,
       smallZoneMergeThreshold,
+      projectProfile,
     });
     let zones = zonesResult.zones;
     if (zonesResult.tokenUsage) {
@@ -359,6 +371,7 @@ export async function runZonesPhase(ctx: AnalyzeContext, extraArgs: string[]): P
           zoneAnchors: zoneAnchors.length > 0 ? zoneAnchors : undefined,
           smallZoneMergeThreshold,
           reuseStructure: true,
+          projectProfile,
         });
         zones = zonesResult.zones;
         if (zonesResult.tokenUsage) {

--- a/packages/sourcevision/src/cli/commands/analyze-phases.ts
+++ b/packages/sourcevision/src/cli/commands/analyze-phases.ts
@@ -54,7 +54,7 @@ import type {
 } from "../sourcevision-core.js";
 import { info } from "../output.js";
 import { bold, cyan, dim, yellow, green, red, loadProjectOverrides } from "@n-dx/llm-client";
-import { buildProjectProfile } from "../../analyzers/project-profile.js";
+import { buildProjectProfile, stripProjectProfileForDisk } from "../../analyzers/project-profile.js";
 
 // ── Shared context passed between phases ─────────────────────────────
 
@@ -340,7 +340,7 @@ export async function runZonesPhase(ctx: AnalyzeContext, extraArgs: string[]): P
     const projectProfile = buildProjectProfile(ctx.absDir, inventory, importsData);
     writeFileSync(
       join(ctx.svDir, DATA_FILES.projectProfile),
-      toCanonicalJSON(projectProfile),
+      toCanonicalJSON(stripProjectProfileForDisk(projectProfile)),
     );
 
     let zonesResult = await analyzeZones(inventory, importsData, {

--- a/packages/sourcevision/src/cli/commands/analyze-phases.ts
+++ b/packages/sourcevision/src/cli/commands/analyze-phases.ts
@@ -357,12 +357,23 @@ export async function runZonesPhase(ctx: AnalyzeContext, extraArgs: string[]): P
     const outPath = join(ctx.svDir, DATA_FILES.zones);
     writeFileSync(outPath, toCanonicalJSON(zones));
 
-    // --full: run remaining enrichment passes up to 4
+    // --full: run remaining enrichment passes up to 4. We stop early when a
+    // pass produces no observable change to zone identity or findings —
+    // continuing past convergence costs ~1 LLM call per zone batch per pass
+    // and contributes nothing. The fingerprint covers zone id, zone name,
+    // findings count, and insight count: if a pass touches any of those it
+    // counts as productive, otherwise we bail.
     if (ctx.fullMode && enrich) {
       const targetPass = 4;
       const currentPass = zones.enrichmentPass ?? 0;
       const passesNeeded = targetPass - currentPass;
 
+      const fingerprint = (z: typeof zones): string => {
+        const names = z.zones.map((zo) => `${zo.id}:${zo.name}`).sort().join("|");
+        return `${names} f=${z.findings?.length ?? 0} i=${z.insights?.length ?? 0}`;
+      };
+
+      let prevFingerprint = fingerprint(zones);
       for (let p = 0; p < passesNeeded; p++) {
         info(`\n${bold(cyan("[phase 4]"))} Enrichment pass ${currentPass + p + 2}...`);
         zonesResult = await analyzeZones(inventory, importsData, {
@@ -378,6 +389,13 @@ export async function runZonesPhase(ctx: AnalyzeContext, extraArgs: string[]): P
           accumulateFromAggregate(ctx.tokenUsage, zonesResult.tokenUsage);
         }
         writeFileSync(outPath, toCanonicalJSON(zones));
+
+        const nextFingerprint = fingerprint(zones);
+        if (nextFingerprint === prevFingerprint) {
+          info(`  ${dim(`Pass converged (no zone or finding changes) — skipping remaining ${passesNeeded - p - 1} pass(es)`)}`);
+          break;
+        }
+        prevFingerprint = nextFingerprint;
       }
     }
 

--- a/packages/sourcevision/src/cli/commands/analyze.ts
+++ b/packages/sourcevision/src/cli/commands/analyze.ts
@@ -37,6 +37,7 @@ import {
 } from "./analyze-phases.js";
 import type { AnalyzeContext } from "./analyze-phases.js";
 import { generatePrMarkdownFile } from "./pr-markdown.js";
+import { buildProjectProfile } from "../../analyzers/project-profile.js";
 
 type PhaseFilter =
   | { type: "all" }
@@ -378,6 +379,16 @@ function generateOutputFiles(ctx: AnalyzeContext): void {
 
       writeFileSync(join(ctx.svDir, DATA_FILES.zones), toCanonicalJSON(zonesData));
     }
+
+    // Project profile — primary language, frameworks, release/build/CI surfaces
+    // and import-graph quality. Written before CONTEXT.md / llms.txt so they
+    // can reference it on a future pass; consumed by the finding LLM prompt
+    // to suppress recommendations that contradict the detected project shape.
+    const projectProfile = buildProjectProfile(ctx.absDir, inventory, importsData);
+    writeFileSync(
+      join(ctx.svDir, DATA_FILES.projectProfile),
+      toCanonicalJSON(projectProfile),
+    );
 
     const llmsTxt = generateLlmsTxt(manifest, inventory, importsData, zonesData, componentsData, classData);
     writeFileSync(join(ctx.svDir, SUPPLEMENTARY_FILES[0]), llmsTxt);

--- a/packages/sourcevision/src/cli/commands/analyze.ts
+++ b/packages/sourcevision/src/cli/commands/analyze.ts
@@ -37,7 +37,7 @@ import {
 } from "./analyze-phases.js";
 import type { AnalyzeContext } from "./analyze-phases.js";
 import { generatePrMarkdownFile } from "./pr-markdown.js";
-import { buildProjectProfile } from "../../analyzers/project-profile.js";
+import { buildProjectProfile, stripProjectProfileForDisk } from "../../analyzers/project-profile.js";
 
 type PhaseFilter =
   | { type: "all" }
@@ -387,7 +387,7 @@ function generateOutputFiles(ctx: AnalyzeContext): void {
     const projectProfile = buildProjectProfile(ctx.absDir, inventory, importsData);
     writeFileSync(
       join(ctx.svDir, DATA_FILES.projectProfile),
-      toCanonicalJSON(projectProfile),
+      toCanonicalJSON(stripProjectProfileForDisk(projectProfile)),
     );
 
     const llmsTxt = generateLlmsTxt(manifest, inventory, importsData, zonesData, componentsData, classData);

--- a/packages/sourcevision/src/language/detect.ts
+++ b/packages/sourcevision/src/language/detect.ts
@@ -23,11 +23,13 @@ import { join, extname } from "node:path";
 import type { LanguageConfig } from "./registry.js";
 import { typescriptConfig } from "./typescript.js";
 import { goConfig } from "./go.js";
+import { swiftConfig } from "./swift.js";
 
 // ── Config registry ─────────────────────────────────────────────────────────
 
 const LANGUAGE_CONFIGS: ReadonlyMap<string, LanguageConfig> = new Map([
   ["go", goConfig],
+  ["swift", swiftConfig],
   ["typescript", typescriptConfig],
   ["javascript", typescriptConfig],
 ]);
@@ -36,7 +38,7 @@ const LANGUAGE_CONFIGS: ReadonlyMap<string, LanguageConfig> = new Map([
  * Valid language identifiers accepted by the `.n-dx.json` `language` field.
  * Includes `"auto"` which triggers marker-based detection.
  */
-export const VALID_LANGUAGE_IDS: readonly string[] = ["typescript", "javascript", "go", "auto"] as const;
+export const VALID_LANGUAGE_IDS: readonly string[] = ["typescript", "javascript", "go", "swift", "auto"] as const;
 
 /**
  * Look up a language config by id. Returns `undefined` for unknown ids.
@@ -54,6 +56,37 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Tiebreak ordering when multiple language markers report identical source
+ * counts: TypeScript wins over Swift wins over Go. This preserves the legacy
+ * "TS wins go.mod+package.json tie" behavior while still giving Swift a
+ * sensible priority over Go on a mixed Swift+Go repo with no source files.
+ */
+function tiebreakRank(config: LanguageConfig): number {
+  if (config === typescriptConfig) return 0;
+  if (config === swiftConfig) return 1;
+  return 2;
+}
+
+/**
+ * Swift marker present? Either `Package.swift` at the root or any top-level
+ * `*.xcodeproj` / `*.xcworkspace` directory. App + library targets typically
+ * have one or the other (often both).
+ */
+async function hasSwiftMarker(rootDir: string): Promise<boolean> {
+  if (await fileExists(join(rootDir, "Package.swift"))) return true;
+  try {
+    const entries = await readdir(rootDir, { withFileTypes: true });
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      if (e.name.endsWith(".xcodeproj") || e.name.endsWith(".xcworkspace")) return true;
+    }
+  } catch {
+    // Unreadable — no marker.
+  }
+  return false;
 }
 
 /**
@@ -77,12 +110,14 @@ async function readConfigOverride(rootDir: string): Promise<string | undefined> 
  * Count source files by language family in the top two directory levels.
  * Performs a shallow scan (not a full recursive walk) for speed.
  */
-async function countSourceFiles(rootDir: string): Promise<{ go: number; ts: number }> {
+async function countSourceFiles(rootDir: string): Promise<{ go: number; ts: number; swift: number }> {
   let go = 0;
   let ts = 0;
+  let swift = 0;
 
   const goExts = goConfig.extensions;
   const tsExts = typescriptConfig.extensions;
+  const swiftExts = swiftConfig.extensions;
 
   // Scan root + one level of subdirectories
   const dirsToScan = [rootDir];
@@ -96,7 +131,7 @@ async function countSourceFiles(rootDir: string): Promise<{ go: number; ts: numb
     }
   } catch {
     // Can't read root — return zeros
-    return { go, ts };
+    return { go, ts, swift };
   }
 
   for (const dir of dirsToScan) {
@@ -107,13 +142,14 @@ async function countSourceFiles(rootDir: string): Promise<{ go: number; ts: numb
         const ext = extname(entry.name);
         if (goExts.has(ext)) go++;
         if (tsExts.has(ext)) ts++;
+        if (swiftExts.has(ext)) swift++;
       }
     } catch {
       // Skip unreadable directories
     }
   }
 
-  return { go, ts };
+  return { go, ts, swift };
 }
 
 // ── Detection ───────────────────────────────────────────────────────────────
@@ -138,29 +174,29 @@ export async function detectLanguage(rootDir: string): Promise<LanguageConfig> {
   }
 
   // Step 2 & 3: Check for language markers
-  const [hasGoMod, hasPackageJson] = await Promise.all([
+  const [hasGoMod, hasPackageJson, hasSwift] = await Promise.all([
     fileExists(join(rootDir, "go.mod")),
     fileExists(join(rootDir, "package.json")),
+    hasSwiftMarker(rootDir),
   ]);
 
-  // Only go.mod → Go
-  if (hasGoMod && !hasPackageJson) {
-    return goConfig;
-  }
+  // Single-marker fast paths.
+  if (hasGoMod && !hasPackageJson && !hasSwift) return goConfig;
+  if (hasSwift && !hasGoMod && !hasPackageJson) return swiftConfig;
+  if (hasPackageJson && !hasGoMod && !hasSwift) return typescriptConfig;
 
-  // Only package.json → TypeScript/JS
-  if (hasPackageJson && !hasGoMod) {
-    return typescriptConfig;
-  }
-
-  // Step 4: Both markers present → file-count tiebreak
-  if (hasGoMod && hasPackageJson) {
+  // Step 4: Multiple markers present — file-count tiebreak picks primary.
+  if (hasGoMod || hasPackageJson || hasSwift) {
     const counts = await countSourceFiles(rootDir);
-    if (counts.go > counts.ts) {
-      return goConfig;
-    }
-    // Equal or TS wins → TypeScript (preserves backward compatibility)
-    return typescriptConfig;
+    const candidates: Array<[number, LanguageConfig]> = [];
+    if (hasGoMod) candidates.push([counts.go, goConfig]);
+    if (hasSwift) candidates.push([counts.swift, swiftConfig]);
+    if (hasPackageJson) candidates.push([counts.ts, typescriptConfig]);
+    candidates.sort((a, b) => {
+      if (a[0] !== b[0]) return b[0] - a[0];
+      return tiebreakRank(a[1]) - tiebreakRank(b[1]);
+    });
+    return candidates[0][1] ?? typescriptConfig;
   }
 
   // Step 5: No markers → fallback to TypeScript/JS
@@ -181,32 +217,37 @@ export async function detectLanguage(rootDir: string): Promise<LanguageConfig> {
  * Returns at least one config — TypeScript/JS as the fallback default.
  */
 export async function detectLanguages(rootDir: string): Promise<LanguageConfig[]> {
-  // Check for language markers
-  const [hasGoMod, hasPackageJson] = await Promise.all([
+  // Check for language markers (Swift adds Package.swift / .xcodeproj /
+  // .xcworkspace; only one needs to be present).
+  const [hasGoMod, hasPackageJson, hasSwift] = await Promise.all([
     fileExists(join(rootDir, "go.mod")),
     fileExists(join(rootDir, "package.json")),
+    hasSwiftMarker(rootDir),
   ]);
 
-  const configs: LanguageConfig[] = [];
+  const present: Array<{ config: LanguageConfig; count: number }> = [];
 
-  if (hasGoMod && hasPackageJson) {
-    // Both present — determine primary via file-count tiebreak, include both
+  // When any markers are present, count source files so we can order by
+  // primary. countSourceFiles is cheap (shallow scan).
+  if (hasGoMod || hasPackageJson || hasSwift) {
     const counts = await countSourceFiles(rootDir);
-    if (counts.go > counts.ts) {
-      configs.push(goConfig, typescriptConfig);
-    } else {
-      configs.push(typescriptConfig, goConfig);
-    }
-  } else if (hasGoMod) {
-    configs.push(goConfig);
-  } else if (hasPackageJson) {
-    configs.push(typescriptConfig);
-  } else {
-    // No markers — fallback to TypeScript/JS
-    configs.push(typescriptConfig);
+    if (hasGoMod) present.push({ config: goConfig, count: counts.go });
+    if (hasSwift) present.push({ config: swiftConfig, count: counts.swift });
+    if (hasPackageJson) present.push({ config: typescriptConfig, count: counts.ts });
   }
 
-  return configs;
+  // No markers → fallback to TypeScript/JS for backward compatibility.
+  if (present.length === 0) {
+    return [typescriptConfig];
+  }
+
+  // Stable ordering by descending file count, ties broken by the same
+  // TS > Swift > Go preference detectLanguage uses.
+  present.sort((a, b) => {
+    if (a.count !== b.count) return b.count - a.count;
+    return tiebreakRank(a.config) - tiebreakRank(b.config);
+  });
+  return present.map((p) => p.config);
 }
 
 /**

--- a/packages/sourcevision/src/language/index.ts
+++ b/packages/sourcevision/src/language/index.ts
@@ -10,6 +10,7 @@ export type { LanguageConfig } from "./registry.js";
 // Language configs
 export { typescriptConfig } from "./typescript.js";
 export { goConfig } from "./go.js";
+export { swiftConfig } from "./swift.js";
 
 // Detection
 export { detectLanguage, detectLanguages, mergeLanguageConfigs, getLanguageConfig, VALID_LANGUAGE_IDS } from "./detect.js";

--- a/packages/sourcevision/src/language/swift.ts
+++ b/packages/sourcevision/src/language/swift.ts
@@ -1,0 +1,68 @@
+/**
+ * Swift language configuration.
+ *
+ * Drives source-file discovery (phase 1 inventory) and the import-parser
+ * gate (phase 2). Without this config, `.swift` files are filtered out of
+ * `parseableExtensions` and never reach the Swift import resolver, leaving
+ * the import graph empty and zone detection falling back to file-tree
+ * proximity.
+ *
+ * @module sourcevision/language/swift
+ */
+
+import type { LanguageConfig } from "./registry.js";
+
+export const swiftConfig: LanguageConfig = {
+  id: "swift",
+  displayName: "Swift",
+
+  extensions: new Set([".swift"]),
+
+  parseableExtensions: new Set([".swift"]),
+
+  testFilePatterns: [
+    // XCTest convention: `*Tests.swift` in a `Tests/` directory.
+    /(?:^|\/)Tests\//,
+    /Tests\.swift$/,
+    // Swift Testing convention: `@Test` annotations live in any file but
+    // file naming typically still follows the *Tests pattern above.
+    /Spec\.swift$/,
+  ],
+
+  configFilenames: new Set([
+    "Package.swift",
+    "Package.resolved",
+    ".swiftpm",
+    "Podfile",
+    "Podfile.lock",
+    "Cartfile",
+    "Cartfile.resolved",
+    "Makefile",
+    "project.yml",       // XcodeGen
+    "project.pbxproj",   // Xcode project
+  ]),
+
+  skipDirectories: new Set([
+    ".build",            // SPM build output
+    "DerivedData",       // Xcode build cache
+    "Pods",              // CocoaPods dependencies
+    "Carthage",          // Carthage dependencies
+    ".swiftpm",          // SPM metadata
+    "build",
+    "dist",
+  ]),
+
+  generatedFilePatterns: [
+    /\.generated\.swift$/,
+    /Generated\/.+\.swift$/,
+  ],
+
+  entryPointPatterns: [
+    // App entry — `@main` lives in the file but we surface the conventional
+    // names that hold it.
+    /(?:^|\/)App\.swift$/,
+    /(?:^|\/)main\.swift$/,
+  ],
+
+  moduleFile: "Package.swift",
+};

--- a/packages/sourcevision/src/schema/data-files.ts
+++ b/packages/sourcevision/src/schema/data-files.ts
@@ -6,6 +6,7 @@ export const DATA_FILES = {
   zones: "zones.json",
   components: "components.json",
   callGraph: "callgraph.json",
+  projectProfile: "project-profile.json",
 } as const;
 
 export const ALL_DATA_FILES = Object.values(DATA_FILES);

--- a/packages/sourcevision/src/schema/v1.ts
+++ b/packages/sourcevision/src/schema/v1.ts
@@ -736,6 +736,14 @@ export interface SourcevisionOutput {
 
 export interface ProjectProfile {
   schemaVersion: string;
+  /**
+   * Absolute project root. In-memory consumers (LLM prompt builders, finding
+   * filters) use this to resolve project-relative file paths for content
+   * probes (header excerpts, snippet anchors). Not persisted: stripped when
+   * the profile is serialized to `.sourcevision/project-profile.json` so the
+   * on-disk artifact stays portable across machines.
+   */
+  projectDir?: string;
   /** Resolved primary language (lowercase, e.g. "typescript", "swift"). */
   primaryLanguage: string;
   /** All detected languages, primary-first. */

--- a/packages/sourcevision/src/schema/v1.ts
+++ b/packages/sourcevision/src/schema/v1.ts
@@ -121,6 +121,14 @@ export interface ImportEdge {
   to: string;
   type: ImportType;
   symbols: string[];
+  /**
+   * Edge weight for community-detection. When set, Louvain uses this directly
+   * instead of `symbols.length`. Lets a resolver express "this edge is heavy"
+   * (e.g. a Swift file that references a target symbol 20 times) vs. a casual
+   * one-line mention. Capped per-resolver to prevent a single hot edge from
+   * dominating the zoning result.
+   */
+  weight?: number;
 }
 
 export interface ExternalImport {

--- a/packages/sourcevision/src/schema/v1.ts
+++ b/packages/sourcevision/src/schema/v1.ts
@@ -155,6 +155,20 @@ export type FindingType = "observation" | "pattern" | "relationship" | "anti-pat
 /** Category distinguishes what kind of issue a finding describes. */
 export type FindingCategory = "structural" | "code" | "documentation";
 
+/**
+ * Concrete code anchor for a finding — file:line(:symbol) coordinates that
+ * point at the evidence the finding is making a claim about. Findings without
+ * anchors are unverified hypotheses; consumers should mark or filter them.
+ */
+export interface FindingAnchor {
+  /** Project-relative file path. */
+  file: string;
+  /** Inclusive [start, end] line range (1-indexed). */
+  lineRange?: [number, number];
+  /** Optional symbol identifier (function/class/type name) within the file. */
+  symbol?: string;
+}
+
 export interface Finding {
   type: FindingType;
   /** Which pass produced this finding */
@@ -167,6 +181,18 @@ export interface Finding {
   related?: string[];
   /** Category: structural (zone boundary opinions), code (real bugs/duplication), documentation (naming/conventions) */
   category?: FindingCategory;
+  /**
+   * Concrete anchors (file/line/symbol) supporting this finding. Empty or
+   * absent ⇒ the finding is an unverified hypothesis. The finding pipeline
+   * may drop or annotate such findings depending on configured strictness.
+   */
+  anchors?: FindingAnchor[];
+  /**
+   * Confidence in the finding itself (0–1). Distinct from zone.confidence —
+   * a low-confidence finding may originate from a high-confidence zone but
+   * still be speculative.
+   */
+  confidence?: number;
 }
 
 /** Reason a file-move is recommended. */
@@ -227,7 +253,24 @@ export interface Zone {
    * cohesion/coupling scores from influencing architectural decisions.
    */
   detectionQuality?: "genuine" | "artifact" | "residual";
+  /**
+   * What evidence backed this zone's membership. A zone derived from a strong
+   * import graph (`imports`) is far more trustworthy than one assembled from
+   * file-tree proximity (`proximity`) when no imports were resolvable —
+   * downstream consumers (LLM prompt, dashboards, CI) MUST gate or annotate
+   * findings derived from proximity-only zones.
+   */
+  evidenceSources?: ZoneEvidenceSource[];
+  /**
+   * Overall confidence in this zone (0–1). Combines cohesion with evidence
+   * source quality: proximity-only zones cap at ~0.3 regardless of cohesion,
+   * since cohesion is meaningless without real edges.
+   */
+  confidence?: number;
 }
+
+/** Where this zone's membership evidence came from. */
+export type ZoneEvidenceSource = "imports" | "proximity" | "declared" | "pinned";
 
 // ── Risk Metrics ────────────────────────────────────────────────────────────
 
@@ -679,4 +722,59 @@ export interface SourcevisionOutput {
   zones: Zones;
   components?: Components;
   callGraph?: CallGraph;
+  projectProfile?: ProjectProfile;
+}
+
+// ── Project profile ─────────────────────────────────────────────────────────
+//
+// First-class project shape detected once during analyze and consumed by every
+// downstream layer (findings prompt, CONTEXT.md, dashboards). Captures facts
+// the LLM cannot reliably infer from a file inventory alone: which frameworks
+// are in use, what release plumbing already exists, where builds and CI live.
+// Findings that contradict the profile (e.g. recommending a VERSION file when
+// releasePlease is true) are filtered before they reach the user.
+
+export interface ProjectProfile {
+  schemaVersion: string;
+  /** Resolved primary language (lowercase, e.g. "typescript", "swift"). */
+  primaryLanguage: string;
+  /** All detected languages, primary-first. */
+  languages: string[];
+  /**
+   * Detected frameworks/runtime ecosystems. Examples: "swiftui", "appkit",
+   * "react", "preact", "nextjs", "express", "rails", "django", "fastify".
+   * Used by the finding prompt to suppress idiomatically-wrong recommendations.
+   */
+  frameworks: string[];
+  /** Detected release/version-management infrastructure. */
+  releaseInfrastructure: ReleaseInfrastructure[];
+  /** Detected build entry points (Makefile, build.sh, Package.swift, etc.). */
+  buildSurfaces: ProjectSurface[];
+  /** Detected CI surfaces (GitHub Actions, GitLab CI, Bitbucket Pipelines). */
+  ciSurfaces: ProjectSurface[];
+  /** Quality of the import graph that backed zone detection. */
+  importGraphQuality: "rich" | "sparse" | "absent";
+}
+
+/** A release-versioning system detected in the repo. */
+export interface ReleaseInfrastructure {
+  /** Kind of release tooling. */
+  kind:
+    | "release-please"
+    | "changesets"
+    | "package.json"
+    | "cargo"
+    | "pyproject"
+    | "git-tag"
+    | "version-file";
+  /** Project-relative path that proves this kind is in use. */
+  evidence: string;
+}
+
+/** A build or CI surface detected in the repo. */
+export interface ProjectSurface {
+  /** Project-relative path. */
+  path: string;
+  /** What this surface is (free-form label, e.g. "Makefile", "GitHub Actions"). */
+  kind: string;
 }

--- a/packages/sourcevision/tests/unit/analyzers/enrich-content-skip.test.ts
+++ b/packages/sourcevision/tests/unit/analyzers/enrich-content-skip.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../../src/analyzers/claude-client.js", async () => {
     setClaudeConfig: vi.fn(),
     getAuthMode: vi.fn(),
     DEFAULT_MODEL: "claude-sonnet-4-6",
+    resolveLightModel: vi.fn(() => "claude-haiku-4-5"),
   };
 });
 

--- a/packages/sourcevision/tests/unit/analyzers/project-profile.test.ts
+++ b/packages/sourcevision/tests/unit/analyzers/project-profile.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildProjectProfile,
+  stripProjectProfileForDisk,
+} from "../../../src/analyzers/project-profile.js";
+import type { Inventory, Imports } from "../../../src/schema/index.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeInventory(files: Array<{ path: string; language: string }>): Inventory {
+  return {
+    files: files.map((f) => ({
+      path: f.path,
+      size: 100,
+      language: f.language,
+      lineCount: 10,
+      hash: "x",
+      role: "library",
+      category: "code",
+    })) as Inventory["files"],
+    summary: { totalFiles: files.length, totalLines: files.length * 10 } as Inventory["summary"],
+  };
+}
+
+function makeImports(edges: Array<{ from: string; to: string }>): Imports {
+  return {
+    edges: edges.map((e) => ({ from: e.from, to: e.to, type: "static", symbols: ["*"] })) as Imports["edges"],
+    external: [],
+    summary: { totalEdges: edges.length, totalExternal: 0, mostImported: [] } as Imports["summary"],
+  };
+}
+
+// ── buildProjectProfile ──────────────────────────────────────────────────────
+
+describe("buildProjectProfile — primary language + languages list", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sv-pp-"));
+  });
+
+  it("orders languages primary-first by file count", () => {
+    const inv = makeInventory([
+      { path: "a.ts", language: "typescript" },
+      { path: "b.ts", language: "typescript" },
+      { path: "c.ts", language: "typescript" },
+      { path: "d.swift", language: "swift" },
+      { path: "e.swift", language: "swift" },
+    ]);
+    const profile = buildProjectProfile(dir, inv, makeImports([]));
+    expect(profile.primaryLanguage).toBe("typescript");
+    expect(profile.languages).toEqual(["typescript", "swift"]);
+  });
+
+  it("falls back to 'unknown' when inventory has no languages", () => {
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    expect(profile.primaryLanguage).toBe("unknown");
+  });
+});
+
+describe("buildProjectProfile — importGraphQuality", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sv-pp-"));
+  });
+
+  it("returns 'absent' when there are no edges", () => {
+    const inv = makeInventory([{ path: "a.swift", language: "swift" }]);
+    const profile = buildProjectProfile(dir, inv, makeImports([]));
+    expect(profile.importGraphQuality).toBe("absent");
+  });
+
+  it("returns 'sparse' when edges/file ratio is below 0.25", () => {
+    const inv = makeInventory(
+      Array.from({ length: 100 }, (_, i) => ({ path: `f${i}.ts`, language: "typescript" })),
+    );
+    const profile = buildProjectProfile(dir, inv, makeImports([{ from: "f0.ts", to: "f1.ts" }]));
+    expect(profile.importGraphQuality).toBe("sparse");
+  });
+
+  it("returns 'rich' when edges/file ratio is at or above 0.25", () => {
+    const inv = makeInventory([
+      { path: "a.ts", language: "typescript" },
+      { path: "b.ts", language: "typescript" },
+      { path: "c.ts", language: "typescript" },
+      { path: "d.ts", language: "typescript" },
+    ]);
+    const profile = buildProjectProfile(dir, inv, makeImports([
+      { from: "a.ts", to: "b.ts" },
+      { from: "b.ts", to: "c.ts" },
+      { from: "c.ts", to: "d.ts" },
+    ]));
+    expect(profile.importGraphQuality).toBe("rich");
+  });
+});
+
+describe("buildProjectProfile — framework detection", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sv-pp-"));
+  });
+
+  it("flags React / preact / express from package.json deps", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({
+      name: "x", version: "1.0.0",
+      dependencies: { react: "^18", express: "^4" },
+      devDependencies: { vitest: "^1" },
+    }));
+    const inv = makeInventory([{ path: "a.ts", language: "typescript" }]);
+    const profile = buildProjectProfile(dir, inv, makeImports([]));
+    expect(profile.frameworks).toEqual(expect.arrayContaining(["react", "express", "vitest"]));
+  });
+
+  it("detects SwiftUI/AppKit from .swift file imports", () => {
+    writeFileSync(
+      join(dir, "App.swift"),
+      `import Foundation\nimport SwiftUI\nimport AppKit\nstruct App {}\n`,
+    );
+    const inv = makeInventory([{ path: "App.swift", language: "swift" }]);
+    const profile = buildProjectProfile(dir, inv, makeImports([]));
+    expect(profile.frameworks).toEqual(expect.arrayContaining(["swiftui", "appkit"]));
+  });
+});
+
+describe("buildProjectProfile — release infrastructure", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sv-pp-"));
+  });
+
+  it("flags release-please when its manifest is present", () => {
+    writeFileSync(join(dir, ".release-please-manifest.json"), `{"x": "1.0.0"}`);
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    expect(profile.releaseInfrastructure.some((r) => r.kind === "release-please")).toBe(true);
+  });
+
+  it("flags changesets when .changeset/ exists", () => {
+    mkdirSync(join(dir, ".changeset"));
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    expect(profile.releaseInfrastructure.some((r) => r.kind === "changesets")).toBe(true);
+  });
+
+  it("flags package.json with a version field", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", version: "1.0.0" }));
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    expect(profile.releaseInfrastructure.some((r) => r.kind === "package.json")).toBe(true);
+  });
+
+  it("flags a build script that uses git tags as 'git-tag'", () => {
+    writeFileSync(join(dir, "build-app.sh"), `#!/bin/bash\nVERSION=$(git describe --tags)\n`);
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    expect(profile.releaseInfrastructure.some((r) => r.kind === "git-tag")).toBe(true);
+  });
+});
+
+describe("buildProjectProfile — build and CI surfaces", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sv-pp-"));
+  });
+
+  it("detects build surfaces (Makefile, build.sh)", () => {
+    writeFileSync(join(dir, "Makefile"), "all:\n\techo hi\n");
+    writeFileSync(join(dir, "build.sh"), "#!/bin/bash\n");
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    const paths = profile.buildSurfaces.map((s) => s.path);
+    expect(paths).toEqual(expect.arrayContaining(["Makefile", "build.sh"]));
+  });
+
+  it("detects GitHub Actions workflows", () => {
+    mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+    writeFileSync(join(dir, ".github", "workflows", "ci.yml"), "name: ci\n");
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    expect(profile.ciSurfaces.some((s) => s.kind === "GitHub Actions"))
+      .toBe(true);
+  });
+});
+
+// ── stripProjectProfileForDisk ──────────────────────────────────────────────
+
+describe("stripProjectProfileForDisk", () => {
+  it("removes the machine-specific projectDir field", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sv-pp-"));
+    const profile = buildProjectProfile(dir, makeInventory([]), makeImports([]));
+    expect(profile.projectDir).toBe(dir);
+    const stripped = stripProjectProfileForDisk(profile);
+    expect(stripped).not.toHaveProperty("projectDir");
+    // Other fields are preserved.
+    expect(stripped.primaryLanguage).toBe(profile.primaryLanguage);
+    expect(stripped.frameworks).toEqual(profile.frameworks);
+  });
+});

--- a/packages/sourcevision/tests/unit/analyzers/swift-imports.test.ts
+++ b/packages/sourcevision/tests/unit/analyzers/swift-imports.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  extractSwiftImportModules,
+  extractSwiftDeclarations,
+  findSymbolReferences,
+  buildSwiftImportGraph,
+} from "../../../src/analyzers/swift-imports.js";
+
+// ── extractSwiftImportModules ────────────────────────────────────────────────
+
+describe("extractSwiftImportModules", () => {
+  it("captures common Apple frameworks", () => {
+    const src = `
+import Foundation
+import SwiftUI
+import AppKit
+import Combine
+`;
+    const mods = extractSwiftImportModules(src);
+    expect(mods).toEqual(["Foundation", "SwiftUI", "AppKit", "Combine"]);
+  });
+
+  it("captures submodule imports (import X.Y)", () => {
+    const src = `import SwiftUI.Color\n`;
+    expect(extractSwiftImportModules(src)).toEqual(["SwiftUI"]);
+  });
+
+  it("captures import access modifiers (import class, import struct)", () => {
+    const src = `
+import class Foundation.NSObject
+import struct Foundation.URL
+`;
+    expect(extractSwiftImportModules(src)).toEqual(["Foundation", "Foundation"]);
+  });
+
+  it("ignores imports inside comments and strings", () => {
+    const src = `
+// import HiddenInComment
+import SwiftUI
+let s = "import HiddenInString"
+`;
+    expect(extractSwiftImportModules(src)).toEqual(["SwiftUI"]);
+  });
+});
+
+// ── extractSwiftDeclarations ─────────────────────────────────────────────────
+
+describe("extractSwiftDeclarations", () => {
+  it("captures class/struct/enum/protocol/actor/extension/typealias", () => {
+    const src = `
+class SchedulerEngine {}
+struct AppEnvironment {}
+enum MenuMode {}
+protocol OverlayPresenting {}
+actor Store {}
+extension AppEnvironment {}
+typealias Handler = () -> Void
+`;
+    const decls = extractSwiftDeclarations(src);
+    expect(new Set(decls)).toEqual(
+      new Set(["SchedulerEngine", "AppEnvironment", "MenuMode", "OverlayPresenting", "Store", "Handler"]),
+    );
+  });
+
+  it("ignores declarations inside string literals and comments", () => {
+    const src = `
+// class HiddenInComment {}
+let note = "class HiddenInString"
+struct Real {}
+`;
+    expect(extractSwiftDeclarations(src)).toEqual(["Real"]);
+  });
+});
+
+// ── findSymbolReferences ─────────────────────────────────────────────────────
+
+describe("findSymbolReferences", () => {
+  it("finds references and ignores comment / string mentions", () => {
+    const src = `
+// uses SchedulerEngine
+let s = "SchedulerEngine"
+let engine = SchedulerEngine()
+let mode: MenuMode = .normal
+`;
+    const refs = findSymbolReferences(src, new Set(["SchedulerEngine", "MenuMode", "Unused"]));
+    expect(refs).toEqual(new Set(["SchedulerEngine", "MenuMode"]));
+  });
+
+  it("returns empty when no symbols match", () => {
+    const src = `let x = 1\nclass Foo {}`;
+    expect(findSymbolReferences(src, new Set(["Bar"]))).toEqual(new Set());
+  });
+});
+
+// ── buildSwiftImportGraph ────────────────────────────────────────────────────
+
+describe("buildSwiftImportGraph", () => {
+  it("builds file→file edges from symbol references and skips self-loops", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sv-swift-"));
+    mkdirSync(join(dir, "App"));
+    writeFileSync(
+      join(dir, "App", "AppEnvironment.swift"),
+      `import Foundation\nclass AppEnvironment {\n  let store = Store()\n}\n`,
+    );
+    writeFileSync(
+      join(dir, "App", "Store.swift"),
+      `import Foundation\nactor Store {}\n`,
+    );
+    writeFileSync(
+      join(dir, "App", "MenuContent.swift"),
+      `import SwiftUI\nstruct MenuContent {\n  let env: AppEnvironment\n  let store: Store\n}\n`,
+    );
+
+    const result = await buildSwiftImportGraph(
+      [
+        { path: "App/AppEnvironment.swift" },
+        { path: "App/Store.swift" },
+        { path: "App/MenuContent.swift" },
+      ],
+      dir,
+    );
+
+    // AppEnvironment uses Store → edge.
+    expect(result.edges).toContainEqual({
+      from: "App/AppEnvironment.swift",
+      to: "App/Store.swift",
+      type: "static",
+      symbols: ["Store"],
+    });
+
+    // MenuContent uses AppEnvironment AND Store → two edges.
+    const fromMenu = result.edges.filter((e) => e.from === "App/MenuContent.swift");
+    const toSet = new Set(fromMenu.map((e) => e.to));
+    expect(toSet).toEqual(new Set(["App/AppEnvironment.swift", "App/Store.swift"]));
+
+    // Store does not reference anything → no outgoing edges.
+    expect(result.edges.filter((e) => e.from === "App/Store.swift")).toEqual([]);
+
+    // External imports captured and classified.
+    const pkgs = new Set(result.external.map((e) => e.package));
+    expect(pkgs).toEqual(new Set(["stdlib:Foundation", "stdlib:SwiftUI"]));
+  });
+
+  it("handles missing files gracefully without throwing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sv-swift-"));
+    const result = await buildSwiftImportGraph(
+      [{ path: "Missing.swift" }],
+      dir,
+    );
+    expect(result.edges).toEqual([]);
+    expect(result.external).toEqual([]);
+  });
+});

--- a/packages/sourcevision/tests/unit/analyzers/swift-imports.test.ts
+++ b/packages/sourcevision/tests/unit/analyzers/swift-imports.test.ts
@@ -78,7 +78,7 @@ struct Real {}
 // ── findSymbolReferences ─────────────────────────────────────────────────────
 
 describe("findSymbolReferences", () => {
-  it("finds references and ignores comment / string mentions", () => {
+  it("counts references and ignores comment / string mentions", () => {
     const src = `
 // uses SchedulerEngine
 let s = "SchedulerEngine"
@@ -86,12 +86,22 @@ let engine = SchedulerEngine()
 let mode: MenuMode = .normal
 `;
     const refs = findSymbolReferences(src, new Set(["SchedulerEngine", "MenuMode", "Unused"]));
-    expect(refs).toEqual(new Set(["SchedulerEngine", "MenuMode"]));
+    expect(refs).toEqual(new Map([["SchedulerEngine", 1], ["MenuMode", 1]]));
+  });
+
+  it("returns the occurrence count when a symbol is used repeatedly", () => {
+    const src = `
+let a = AppEnvironment()
+let b = AppEnvironment.shared
+let c = AppEnvironment()
+`;
+    const refs = findSymbolReferences(src, new Set(["AppEnvironment"]));
+    expect(refs.get("AppEnvironment")).toBe(3);
   });
 
   it("returns empty when no symbols match", () => {
     const src = `let x = 1\nclass Foo {}`;
-    expect(findSymbolReferences(src, new Set(["Bar"]))).toEqual(new Set());
+    expect(findSymbolReferences(src, new Set(["Bar"]))).toEqual(new Map());
   });
 });
 
@@ -123,12 +133,13 @@ describe("buildSwiftImportGraph", () => {
       dir,
     );
 
-    // AppEnvironment uses Store → edge.
+    // AppEnvironment uses Store → edge with weight 1 (single reference).
     expect(result.edges).toContainEqual({
       from: "App/AppEnvironment.swift",
       to: "App/Store.swift",
       type: "static",
       symbols: ["Store"],
+      weight: 1,
     });
 
     // MenuContent uses AppEnvironment AND Store → two edges.
@@ -152,5 +163,54 @@ describe("buildSwiftImportGraph", () => {
     );
     expect(result.edges).toEqual([]);
     expect(result.external).toEqual([]);
+  });
+
+  it("edge weight reflects total references across symbols (capped at 10)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sv-swift-"));
+    // AppEnvironment declares one type. The consumer references it 4 times.
+    writeFileSync(
+      join(dir, "AppEnvironment.swift"),
+      `class AppEnvironment {}\n`,
+    );
+    writeFileSync(
+      join(dir, "Consumer.swift"),
+      `
+let a = AppEnvironment()
+let b = AppEnvironment.shared
+func make() -> AppEnvironment { AppEnvironment() }
+`,
+    );
+
+    const result = await buildSwiftImportGraph(
+      [{ path: "AppEnvironment.swift" }, { path: "Consumer.swift" }],
+      dir,
+    );
+
+    const edge = result.edges.find(
+      (e) => e.from === "Consumer.swift" && e.to === "AppEnvironment.swift",
+    );
+    expect(edge).toBeDefined();
+    expect(edge!.weight).toBe(4);
+  });
+
+  it("caps edge weight to prevent a single hot edge from dominating zoning", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sv-swift-"));
+    writeFileSync(
+      join(dir, "AppEnvironment.swift"),
+      `class AppEnvironment {}\n`,
+    );
+    // 30 references — should be capped at 10.
+    const consumerBody = Array.from({ length: 30 }, (_, i) => `let x${i} = AppEnvironment()`).join("\n");
+    writeFileSync(join(dir, "Consumer.swift"), consumerBody + "\n");
+
+    const result = await buildSwiftImportGraph(
+      [{ path: "AppEnvironment.swift" }, { path: "Consumer.swift" }],
+      dir,
+    );
+
+    const edge = result.edges.find(
+      (e) => e.from === "Consumer.swift" && e.to === "AppEnvironment.swift",
+    );
+    expect(edge!.weight).toBe(10);
   });
 });

--- a/packages/sourcevision/tests/unit/analyzers/zone-detection.test.ts
+++ b/packages/sourcevision/tests/unit/analyzers/zone-detection.test.ts
@@ -449,26 +449,24 @@ describe("analyzeZones", () => {
     expect(run1).toEqual(run2);
   });
 
-  it("excludes test files from cohesion/coupling metric computation", async () => {
-    // Two source files form a tight cluster (cohesion=1),
-    // plus a test file that imports from an external zone.
-    // Without test-file exclusion, the test→external edge would inflate coupling.
+  it("quarantines tests living in a test-only directory (Swift Tests/ layout)", async () => {
+    // Tests that live in a TEST-ONLY directory get quarantined into their
+    // own zone so they don't share a zone with the implementation they
+    // assert against. (Colocated tests like Go's _test.go stay with their
+    // package — covered separately below.)
     const inventory = makeInventory([
       makeFileEntry("src/core/a.ts"),
       makeFileEntry("src/core/b.ts"),
-      makeFileEntry("src/core/a.test.ts", { role: "test" }),
+      makeFileEntry("tests/core/a.test.ts", { role: "test" }),
       makeFileEntry("src/other/x.ts"),
       makeFileEntry("src/other/y.ts"),
       makeFileEntry("src/other/z.ts"),
     ]);
     const imports = makeImports([
-      // Core cluster: a↔b
       makeEdge("src/core/a.ts", "src/core/b.ts"),
       makeEdge("src/core/b.ts", "src/core/a.ts"),
-      // Test imports from external zone
-      makeEdge("src/core/a.test.ts", "src/core/a.ts"),
-      makeEdge("src/core/a.test.ts", "src/other/x.ts"),
-      // Other cluster
+      makeEdge("tests/core/a.test.ts", "src/core/a.ts"),
+      makeEdge("tests/core/a.test.ts", "src/other/x.ts"),
       makeEdge("src/other/x.ts", "src/other/y.ts"),
       makeEdge("src/other/y.ts", "src/other/z.ts"),
       makeEdge("src/other/x.ts", "src/other/z.ts"),
@@ -476,17 +474,36 @@ describe("analyzeZones", () => {
 
     const { zones: result } = await analyzeZones(inventory, imports, { enrich: false });
 
-    // Find the zone containing core files
     const coreZone = result.zones.find((z) => z.files.includes("src/core/a.ts"));
     expect(coreZone).toBeDefined();
-
-    // Test file should still be a zone member (not excluded from membership)
-    expect(coreZone!.files).toContain("src/core/a.test.ts");
-
-    // But coupling should only reflect source-file edges:
-    // a.ts and b.ts both only connect to each other → coupling should be 0
-    // (if test file were counted, the test→other/x.ts edge would add coupling)
+    expect(coreZone!.files).not.toContain("tests/core/a.test.ts");
     expect(coreZone!.coupling).toBe(0);
+    const testsZone = result.zones.find((z) => z.files.includes("tests/core/a.test.ts"));
+    expect(testsZone).toBeDefined();
+    expect(testsZone!.files).not.toContain("src/core/a.ts");
+  });
+
+  it("keeps colocated tests (Go-style _test.go) inside their production package zone", async () => {
+    // When a test file lives in a directory that ALSO contains production
+    // files (Go's `internal/foo/foo_test.go` next to `foo.go`), the test
+    // belongs with its package — the test-only-directory heuristic doesn't
+    // fire and the test gets partitioned by Louvain alongside production.
+    const inventory = makeInventory([
+      makeFileEntry("internal/handler/user.go"),
+      makeFileEntry("internal/handler/user_test.go", { role: "test" }),
+      makeFileEntry("internal/service/user.go"),
+    ]);
+    const imports = makeImports([
+      makeEdge("internal/handler/user.go", "internal/service/user.go"),
+      makeEdge("internal/handler/user_test.go", "internal/handler/user.go"),
+    ]);
+
+    const { zones: result } = await analyzeZones(inventory, imports, { enrich: false });
+
+    const handlerZone = result.zones.find((z) => z.files.includes("internal/handler/user.go"));
+    expect(handlerZone).toBeDefined();
+    // Colocated test stays with its package.
+    expect(handlerZone!.files).toContain("internal/handler/user_test.go");
   });
 });
 

--- a/packages/sourcevision/tests/unit/analyzers/zone-enrichment.test.ts
+++ b/packages/sourcevision/tests/unit/analyzers/zone-enrichment.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../src/analyzers/claude-client.js", async () => {
     setClaudeConfig: vi.fn(),
     getAuthMode: vi.fn(),
     DEFAULT_MODEL: "claude-sonnet-4-6",
+    resolveLightModel: vi.fn(() => "claude-haiku-4-5"),
   };
 });
 

--- a/packages/sourcevision/tests/unit/analyzers/zone-subdivision.test.ts
+++ b/packages/sourcevision/tests/unit/analyzers/zone-subdivision.test.ts
@@ -192,9 +192,12 @@ describe("subdivideZone", () => {
 });
 
 describe("SUBDIVISION_THRESHOLD", () => {
-  it("is set to a reasonable value", () => {
-    expect(SUBDIVISION_THRESHOLD).toBeGreaterThanOrEqual(30);
-    expect(SUBDIVISION_THRESHOLD).toBeLessThanOrEqual(100);
+  it("absolute floor stays in a sane range (formerly flat threshold)", () => {
+    // The threshold went from a flat 50 to a project-size-relative
+    // function; SUBDIVISION_THRESHOLD now exports the absolute floor that
+    // applies on small projects.
+    expect(SUBDIVISION_THRESHOLD).toBeGreaterThanOrEqual(8);
+    expect(SUBDIVISION_THRESHOLD).toBeLessThanOrEqual(20);
   });
 });
 

--- a/packages/sourcevision/tests/unit/language/detect.test.ts
+++ b/packages/sourcevision/tests/unit/language/detect.test.ts
@@ -98,8 +98,8 @@ describe("detectLanguage", () => {
 });
 
 describe("VALID_LANGUAGE_IDS", () => {
-  it("contains the four expected values", () => {
-    expect(VALID_LANGUAGE_IDS).toEqual(["typescript", "javascript", "go", "auto"]);
+  it("contains the five expected values", () => {
+    expect(VALID_LANGUAGE_IDS).toEqual(["typescript", "javascript", "go", "swift", "auto"]);
   });
 });
 

--- a/packages/web/src/viewer/styles/cards.css
+++ b/packages/web/src/viewer/styles/cards.css
@@ -85,62 +85,122 @@
 .meter-fill.mid { background: var(--orange); }
 .meter-fill.bad { background: var(--red); }
 
-/* Finding cards */
+/* ── Finding cards ─────────────────────────────────────────────────────────
+   Rethink: severity tints + left bars made every dashboard look like an AI
+   dropped a flood of warning shouts on the page. Instead:
+   - Cards have a single neutral surface — no severity background, no
+     "severity stripe" on the left edge. The card chrome doesn't compete
+     with the actual content.
+   - Severity is signaled by a small colored ICON + small-caps LABEL on the
+     meta row. Color sits on the symbol, not on the entire card.
+   - Type, scope, and severity live in a single quiet meta line above the
+     body — separated by `·` rather than stacked badges with their own
+     backgrounds.
+   - Body text is the visual anchor: high contrast, comfortable reading
+     size, leading optimized for prose. Everything else recedes.
+   Each severity uses --finding-tone-* so dark/light themes get matched
+   tones without inverting backgrounds. */
 .finding-card {
+  --finding-tone: var(--text-dim);
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 8px;
-  font-size: 13px;
-  line-height: 1.5;
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text);
+  transition: border-color 0.12s ease, background 0.12s ease;
 }
 
-.finding-card p { margin: 4px 0; }
-
-.finding-card.severity-critical { border-left: 3px solid var(--red); }
-.finding-card.severity-warning { border-left: 3px solid var(--orange); }
-.finding-card.severity-info { border-left: 3px solid var(--accent); }
-
-.finding-scope {
-  font-size: 11px;
-  color: var(--text-dim);
-  font-family: monospace;
-  margin-left: 8px;
+.finding-card:hover {
+  border-color: color-mix(in srgb, var(--text-dim) 28%, var(--border));
 }
 
-.finding-related {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 8px;
-}
+.finding-card p { margin: 0; }
 
-.finding-related code {
-  font-size: 11px;
-  background: var(--bg-hover);
-  padding: 1px 6px;
-  border-radius: 3px;
-  color: var(--text-dim);
-}
+/* Per-severity ACCENT ONLY (icon + label). No card-background tint, no
+   left bar. Override the bare `.severity-warning` rules in tables.css
+   that would otherwise wash the entire card orange. */
+.finding-card.severity-info    { --finding-tone: var(--accent); background: var(--bg-surface); }
+.finding-card.severity-warning { --finding-tone: var(--orange); background: var(--bg-surface); }
+.finding-card.severity-critical { --finding-tone: var(--red);   background: var(--bg-surface); }
 
-/* Richer finding cards */
 .finding-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 4px;
+  gap: 10px;
+  margin-bottom: 8px;
   flex-wrap: wrap;
+  font-size: 11px;
 }
 
 .finding-icon {
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
+  color: var(--finding-tone);
+  font-size: 13px;
+  line-height: 1;
+}
+
+/* Severity label sits inline next to its icon — small caps, color-keyed.
+   No background, no border, no pill chrome. */
+.finding-card .severity-badge {
+  background: transparent;
+  color: var(--finding-tone);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0;
+}
+
+.finding-type-badge {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  text-transform: lowercase;
+  padding: 0;
+  background: transparent;
+}
+.finding-type-badge::before {
+  content: "·";
+  margin-right: 8px;
+  color: var(--text-muted, var(--text-dim));
+  font-weight: 500;
+}
+
+.finding-scope-link {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.finding-scope-link::before {
+  content: "·";
+  margin-right: 4px;
+  color: var(--text-muted, var(--text-dim));
+  font-family: inherit;
+}
+
+.finding-zone-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
 }
 
 .finding-text {
-  margin: 4px 0;
-  line-height: 1.6;
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text);
 }
 
 .finding-meta {
@@ -148,34 +208,29 @@
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
-  margin-top: 6px;
-}
-
-.finding-zone-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  display: inline-block;
-}
-
-.finding-scope-link {
+  margin-top: 10px;
   font-size: 11px;
-  color: var(--accent-dim);
-  font-family: monospace;
-  display: inline-flex;
-  align-items: center;
+}
+
+.finding-related {
+  display: flex;
+  flex-wrap: wrap;
   gap: 4px;
 }
 
-.finding-type-badge {
-  display: inline-block;
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: 10px;
-  font-weight: 500;
-  background: var(--bg-hover);
+.finding-related code {
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: color-mix(in srgb, var(--bg-hover) 50%, transparent);
+  padding: 2px 6px;
+  border-radius: 4px;
   color: var(--text-dim);
-  text-transform: capitalize;
+  cursor: default;
+  transition: color 0.12s ease;
+}
+
+.finding-related code:hover {
+  color: var(--text);
 }
 
 .finding-related-label {
@@ -184,12 +239,11 @@
   font-weight: 500;
 }
 
-.finding-related code {
-  cursor: default;
-  transition: color 0.1s;
+.finding-scope {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
-
-.finding-related code:hover { color: var(--text); }
 
 /* Getting started card */
 .getting-started {

--- a/packages/web/src/viewer/styles/import-graph.css
+++ b/packages/web/src/viewer/styles/import-graph.css
@@ -1178,10 +1178,10 @@
    .ig-side, so this only kicks in when the user is exploring without the
    modal open. Applies to ANY .ig-graph-shell so the layout is consistent
    between the codebase-map view and the per-zone view. */
-@media (min-width: 1280px) {
+@media (min-width: 1100px) {
   .ig-graph-shell {
     position: relative;
-    flex-direction: row;
+    flex-direction: row !important;
     align-items: stretch;
   }
   .ig-graph-shell-zone {
@@ -1196,11 +1196,11 @@
     z-index: 1;
   }
   .ig-graph-shell .ig-main {
-    flex: 1 1 0;
+    flex: 1 1 0 !important;
     min-width: 0;
   }
   .ig-graph-shell .ig-side {
-    flex: 0 0 320px;
+    flex: 0 0 320px !important;
     max-width: 360px;
     grid-column: auto;
     grid-template-columns: 1fr;
@@ -1210,9 +1210,18 @@
 }
 @media (min-width: 1600px) {
   .ig-graph-shell .ig-side {
-    flex-basis: 360px;
-    max-width: 400px;
+    flex-basis: 380px !important;
+    max-width: 420px;
   }
+}
+
+/* Per-zone metric tiles tone down the project-total tile chrome so the
+   zone-scoped stats read as scoped detail rather than masthead headlines. */
+.ig-atlas-metrics-zone .ig-metric-value {
+  font-size: 1.1rem;
+}
+.ig-atlas-metrics-zone .ig-metric-tile {
+  padding: 8px 10px;
 }
 
 /* ── Edge hover spotlight ──────────────────────────────────────────────────

--- a/packages/web/src/viewer/styles/import-graph.css
+++ b/packages/web/src/viewer/styles/import-graph.css
@@ -1172,6 +1172,45 @@
   gap: 10px;
 }
 
+/* Wide-screen side-by-side: on viewports with the room for it AND when a
+   zone is active, dock the side panel (current selection + shortcuts) to
+   the right of the Zone Map instead of stacking it underneath. The street-
+   view dialog rule below already hides .ig-side, so this only kicks in when
+   the user is exploring without the modal open. */
+@media (min-width: 1280px) {
+  .ig-graph-shell-zone {
+    position: relative;
+    flex-direction: row;
+    align-items: stretch;
+    /* Make room for the floating "Showing key routes…" pseudo-pill so it
+       doesn't get stretched as a flex row item. */
+    padding-top: 44px;
+  }
+  .ig-graph-shell-zone::before {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 1;
+  }
+  .ig-graph-shell-zone .ig-main {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+  .ig-graph-shell-zone .ig-side {
+    flex: 0 0 320px;
+    max-width: 360px;
+    grid-column: auto;
+    grid-template-columns: 1fr;
+    align-self: stretch;
+  }
+}
+@media (min-width: 1600px) {
+  .ig-graph-shell-zone .ig-side {
+    flex-basis: 360px;
+    max-width: 400px;
+  }
+}
+
 .ig-graph-shell .ig-panel-desc,
 .ig-graph-shell .ig-callout {
   display: none;

--- a/packages/web/src/viewer/styles/import-graph.css
+++ b/packages/web/src/viewer/styles/import-graph.css
@@ -496,7 +496,18 @@
 }
 
 .ig-zone-minimap .ig-zone-network svg {
-  min-height: clamp(500px, 62vh, 760px);
+  /* The per-zone map's viewBox is 980×640 (~1.53:1). Without an aspect-ratio
+     hint the SVG stretches to container width and then, via preserveAspectRatio
+     "meet", inflates its height proportionally — on a wide screen (~1700px)
+     that's >1100px and the map alone eats the viewport. Pin the aspect ratio
+     so the SVG sizes to its viewBox shape, then cap the height so it never
+     dominates the page regardless of how wide the container gets. */
+  width: 100%;
+  height: auto;
+  aspect-ratio: 980 / 640;
+  max-height: min(60vh, 680px);
+  min-height: 360px;
+  margin: 0 auto;
 }
 
 .ig-zone-overview-empty {

--- a/packages/web/src/viewer/styles/import-graph.css
+++ b/packages/web/src/viewer/styles/import-graph.css
@@ -1178,15 +1178,20 @@
    .ig-side, so this only kicks in when the user is exploring without the
    modal open. Applies to ANY .ig-graph-shell so the layout is consistent
    between the codebase-map view and the per-zone view. */
+/* Side-by-side: .ig-side is a child of .ig-main (sibling of .ig-zone-overview),
+   NOT a direct child of .ig-graph-shell — so the layout grid lives on
+   .ig-main. Wide screens get a 2-column grid: zone overview on the left,
+   Current Selection docked on the right. !important defends against the
+   base `.ig-graph-shell .ig-main { grid-template-columns: 1fr }` rule and
+   the base `.ig-graph-shell .ig-side { grid-column: 1/-1 }` rule that would
+   otherwise force the side panel to span full width. */
 @media (min-width: 1100px) {
   .ig-graph-shell {
     position: relative;
-    flex-direction: row !important;
-    align-items: stretch;
   }
   .ig-graph-shell-zone {
     /* Room for the floating "Showing key routes…" ::before pill so it
-       doesn't get stretched as a flex row item. */
+       doesn't sit on top of the map content. */
     padding-top: 44px;
   }
   .ig-graph-shell-zone::before {
@@ -1196,22 +1201,21 @@
     z-index: 1;
   }
   .ig-graph-shell .ig-main {
-    flex: 1 1 0 !important;
-    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) 320px !important;
+    grid-auto-flow: column;
   }
-  .ig-graph-shell .ig-side {
-    flex: 0 0 320px !important;
-    max-width: 360px;
-    grid-column: auto;
-    grid-template-columns: 1fr;
+  .ig-graph-shell .ig-main .ig-side {
+    grid-column: 2 / 3 !important;
+    grid-row: 1 / -1;
     align-self: stretch;
     overflow: auto;
+    max-height: 100%;
+    grid-template-columns: 1fr;
   }
 }
 @media (min-width: 1600px) {
-  .ig-graph-shell .ig-side {
-    flex-basis: 380px !important;
-    max-width: 420px;
+  .ig-graph-shell .ig-main {
+    grid-template-columns: minmax(0, 1fr) 380px !important;
   }
 }
 

--- a/packages/web/src/viewer/styles/import-graph.css
+++ b/packages/web/src/viewer/styles/import-graph.css
@@ -1172,17 +1172,20 @@
   gap: 10px;
 }
 
-/* Wide-screen side-by-side: on viewports with the room for it AND when a
-   zone is active, dock the side panel (current selection + shortcuts) to
-   the right of the Zone Map instead of stacking it underneath. The street-
-   view dialog rule below already hides .ig-side, so this only kicks in when
-   the user is exploring without the modal open. */
+/* Wide-screen side-by-side: dock the side panel (current selection +
+   shortcuts) to the right of the map column instead of stacking it
+   underneath. The street-view dialog rule further below already hides
+   .ig-side, so this only kicks in when the user is exploring without the
+   modal open. Applies to ANY .ig-graph-shell so the layout is consistent
+   between the codebase-map view and the per-zone view. */
 @media (min-width: 1280px) {
-  .ig-graph-shell-zone {
+  .ig-graph-shell {
     position: relative;
     flex-direction: row;
     align-items: stretch;
-    /* Make room for the floating "Showing key routes…" pseudo-pill so it
+  }
+  .ig-graph-shell-zone {
+    /* Room for the floating "Showing key routes…" ::before pill so it
        doesn't get stretched as a flex row item. */
     padding-top: 44px;
   }
@@ -1192,23 +1195,72 @@
     left: 12px;
     z-index: 1;
   }
-  .ig-graph-shell-zone .ig-main {
+  .ig-graph-shell .ig-main {
     flex: 1 1 0;
     min-width: 0;
   }
-  .ig-graph-shell-zone .ig-side {
+  .ig-graph-shell .ig-side {
     flex: 0 0 320px;
     max-width: 360px;
     grid-column: auto;
     grid-template-columns: 1fr;
     align-self: stretch;
+    overflow: auto;
   }
 }
 @media (min-width: 1600px) {
-  .ig-graph-shell-zone .ig-side {
+  .ig-graph-shell .ig-side {
     flex-basis: 360px;
     max-width: 400px;
   }
+}
+
+/* ── Edge hover spotlight ──────────────────────────────────────────────────
+   The street view's many overlapping routes are hard to trace by eye, so
+   pointer hover spotlights one connection at a time. Each edge is wrapped in
+   an .ig-edge-group with an invisible .ig-edge-hit path beneath the visible
+   one for forgiving hover targeting; the visible path goes opaque/dim based
+   on whether it's the hovered edge, touches the hovered node, or neither. */
+.ig-edge-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 14;
+  pointer-events: stroke;
+  cursor: pointer;
+}
+.ig-edge-group .ig-edge {
+  pointer-events: none;
+  transition: opacity 0.12s ease, stroke 0.12s ease, stroke-width 0.12s ease;
+}
+.ig-edge.ig-edge-dim {
+  opacity: 0.18;
+}
+.ig-edge.ig-edge-active {
+  opacity: 1;
+  stroke: var(--accent);
+  stroke-width: 2.4;
+}
+.ig-edge.ig-edge-active.ig-edge-cross {
+  stroke: color-mix(in srgb, var(--accent) 60%, var(--orange));
+}
+
+.ig-edge-label {
+  transition: opacity 0.12s ease;
+}
+.ig-edge-label.ig-edge-label-active {
+  opacity: 1;
+  font-weight: 700;
+}
+
+/* Node spotlight — matches the edge logic so the visual story stays whole. */
+.ig-node.ig-node-dim {
+  opacity: 0.28;
+  transition: opacity 0.12s ease;
+}
+.ig-node.ig-node-related rect,
+.ig-node.ig-node-hover rect {
+  stroke: var(--accent);
+  stroke-width: 2;
 }
 
 .ig-graph-shell .ig-panel-desc,

--- a/packages/web/src/viewer/styles/import-graph.css
+++ b/packages/web/src/viewer/styles/import-graph.css
@@ -308,6 +308,23 @@
   color: var(--text-muted, var(--text-dim));
 }
 
+/* File path inline next to the FILE STREET VIEW kicker. Reset the
+   uppercase/tracking from the parent so the path stays readable, and
+   render it as monospaced text the same way file paths look elsewhere. */
+.ig-graph-head-path {
+  color: var(--text);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.ig-graph-head-path code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  background: color-mix(in srgb, var(--bg-hover) 38%, transparent);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
 .ig-graph-scope {
   margin: 3px 0 0;
   color: var(--text-dim);

--- a/packages/web/src/viewer/views/graph.ts
+++ b/packages/web/src/viewer/views/graph.ts
@@ -1502,7 +1502,15 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
                   h("h3", null, activeZone.name),
                 ),
                 h("div", { class: "ig-zone-overview-stats" },
-                  h("span", null, `${activeZone.files.length} files`),
+                  // Show this zone's share of the project as X/Y so the user
+                  // can read both "how big is this zone" and "how big is the
+                  // codebase" at a glance, instead of just an unanchored
+                  // file count.
+                  h("span", null,
+                    inventory
+                      ? `${activeZone.files.length} / ${inventory.files.length} files`
+                      : `${activeZone.files.length} files`,
+                  ),
                   h("span", null, `${activeZoneInternalEdges} internal imports`),
                   h("span", null, `${activeZoneInbound} in / ${activeZoneOutbound} out`),
                 ),

--- a/packages/web/src/viewer/views/graph.ts
+++ b/packages/web/src/viewer/views/graph.ts
@@ -172,15 +172,6 @@ function panViewport(view: Viewport, dx: number, dy: number): Viewport {
   return { ...view, x: view.x + dx, y: view.y + dy };
 }
 
-function zoomViewport(view: Viewport, deltaY: number): Viewport {
-  return { ...view, k: clamp(view.k * (deltaY < 0 ? 1.12 : 0.88), 0.55, 2.6) };
-}
-
-function wheelViewport(view: Viewport, event: WheelEvent): Viewport {
-  if (event.ctrlKey || event.metaKey) return zoomViewport(view, event.deltaY);
-  return panViewport(view, -event.deltaX, -event.deltaY);
-}
-
 // Bounded zoom for the Codebase/Zone maps — not an infinite canvas.
 const MAP_ZOOM_MIN = 0.8;
 const MAP_ZOOM_MAX = 4;
@@ -686,7 +677,7 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
     const cy = event.clientY;
     if (event.ctrlKey || event.metaKey) {
       // Trackpad pinch / explicit zoom — anchor at the cursor.
-      const factor = event.deltaY < 0 ? 1.12 : 1 / 1.12;
+      const factor = event.deltaY < 0 ? 1.03 : 1 / 1.03;
       updateSurfaceView(surface, (view) => zoomMapToFocal(view, view.k * factor, cx, cy, svg));
     } else {
       const vb = svg.viewBox.baseVal;
@@ -1841,6 +1832,20 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
           h("div", { class: "ig-graph-title-block" },
             h("span", { class: "ig-graph-head-label" },
               streetViewMode === "dialog" ? "File street view" : "Dependency preview",
+              // Surface the focused file path inline next to the header so
+              // the user always knows what they're inspecting without
+              // hunting for the highlighted node.
+              streetViewMode === "dialog" && mode === "file" && focusFile
+                ? h("span", { class: "ig-graph-head-path", title: focusFile },
+                    " · ",
+                    h("code", null, focusFile),
+                  )
+                : streetViewMode === "dialog" && mode === "package" && focusPackage
+                  ? h("span", { class: "ig-graph-head-path", title: focusPackage },
+                      " · ",
+                      h("code", null, focusPackage),
+                    )
+                  : null,
             ),
             h("p", { class: "ig-graph-scope" },
               `${graphNodeCount} nodes · ${graphEdgeCount} imports shown · ${graphCrossEdgeCount} cross-boundary · ${graphScopeLabel}`,
@@ -1882,18 +1887,11 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
             onPointerMove: handlePointerMove,
             onPointerUp: endDrag,
             onPointerLeave: endDrag,
-            onWheel: (event: WheelEvent) => {
-              event.preventDefault();
-              setDepView((view) => wheelViewport(view, event));
-            },
+            onWheel: (event: WheelEvent) => handleSurfaceWheel("dep", event),
+            onTouchStart: (event: TouchEvent) => beginPinch("dep", event),
+            onTouchMove: movePinch,
+            onTouchEnd: endPinch,
           },
-            h("rect", {
-              class: "ig-svg-bg",
-              x: 0,
-              y: 0,
-              width: svgW,
-              height: svgH,
-            }),
             h("defs", null,
               h("marker", {
                 id: "ig-arrow",

--- a/packages/web/src/viewer/views/graph.ts
+++ b/packages/web/src/viewer/views/graph.ts
@@ -441,6 +441,23 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
     return () => window.removeEventListener("keydown", onKey);
   }, [streetViewMode, zoneFilter]);
 
+  // Click outside the File Street View shell closes it, mirroring the Escape
+  // shortcut. The dialog already fills the main content area, so anywhere
+  // outside graphPanelRef (sidebar, breadcrumb bar, detail panel) is "outside".
+  useEffect(() => {
+    if (streetViewMode !== "dialog") return;
+    const onDown = (event: MouseEvent) => {
+      const panel = graphPanelRef.current;
+      if (!panel) return;
+      const target = event.target as Node | null;
+      if (target && panel.contains(target)) return;
+      setStreetViewMode("closed");
+      setHoverPreviewFile(null);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [streetViewMode]);
+
   const subgraph = useMemo(() => {
     if (!imports || !focusFile || mode !== "file") return null;
     let ball = expandNeighborhood(focusFile, imports, DEFAULT_DEPTH);
@@ -1176,6 +1193,34 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
         edgeShift.set(idx, (k - (n - 1) / 2) * 10);
       });
     }
+
+    // Cross-zone label deduplication. Without this, three edges from
+    // UI Overlays → App-Core Bridge each carry the identical
+    // "UI Overlays -> App-Core Bridge" string and stack on top of each
+    // other in the diagram. Group by zone pair, pick one representative
+    // edge per group, and emit a single "(×N)" label at the average
+    // midpoint of the bundle.
+    const crossPairFirstIdx = new Map<string, number>();
+    const crossPairCount = new Map<string, number>();
+    const crossPairCentroid = new Map<string, { x: number; y: number; n: number }>();
+    edges.forEach((e, i) => {
+      if (!zones || !isCrossZoneEdge(e.from, e.to, zones)) return;
+      const fz = fileToZoneId(e.from, zones);
+      const tz = fileToZoneId(e.to, zones);
+      if (!fz || !tz) return;
+      const a = visualPosMap.get(e.from);
+      const b = visualPosMap.get(e.to);
+      if (!a || !b) return;
+      const key = `${fz}|${tz}`;
+      crossPairCount.set(key, (crossPairCount.get(key) ?? 0) + 1);
+      if (!crossPairFirstIdx.has(key)) crossPairFirstIdx.set(key, i);
+      const cur = crossPairCentroid.get(key) ?? { x: 0, y: 0, n: 0 };
+      cur.x += (a.x + b.x) / 2;
+      cur.y += (a.y + b.y) / 2;
+      cur.n += 1;
+      crossPairCentroid.set(key, cur);
+    });
+
     edges.forEach((e, i) => {
       const a = visualPosMap.get(e.from);
       const b = visualPosMap.get(e.to);
@@ -1186,13 +1231,32 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
       const toZone = fileToZoneId(e.to, zones);
       const cross = isCrossZoneEdge(e.from, e.to, zones);
       const shift = edgeShift.get(i) ?? 0;
+      const pairKey = cross && fromZone && toZone ? `${fromZone}|${toZone}` : null;
+      const isRep = pairKey !== null && crossPairFirstIdx.get(pairKey) === i;
+      const count = pairKey ? crossPairCount.get(pairKey) ?? 1 : 1;
+      const centroid = pairKey ? crossPairCentroid.get(pairKey) : null;
+      let labelX: number | undefined = (a.x + b.x) / 2 + shift;
+      let labelY: number | undefined = (a.y + b.y) / 2 - 8;
+      let label: string | undefined;
+      if (isRep && zones && fromZone && toZone) {
+        label = `${zoneDisplayName(zones, fromZone)} → ${zoneDisplayName(zones, toZone)}${count > 1 ? ` ×${count}` : ""}`;
+        if (centroid && centroid.n > 0) {
+          labelX = centroid.x / centroid.n;
+          labelY = centroid.y / centroid.n - 8;
+        }
+      } else if (cross) {
+        // Edges in a duplicated cross-zone group still get a position but no
+        // label string — keeps the existing structure for any consumer that
+        // expects labelX/labelY pairs on every cross edge.
+        label = undefined;
+      }
       edgePaths.push({
         key: `${e.from}->${e.to}:${e.type}`,
         d: elbowPath(a.x + wFrom, a.y, b.x - wTo, b.y, shift),
         cross,
-        label: cross && zones && fromZone && toZone ? `${zoneDisplayName(zones, fromZone)} -> ${zoneDisplayName(zones, toZone)}` : undefined,
-        labelX: (a.x + b.x) / 2 + shift,
-        labelY: (a.y + b.y) / 2 - 8,
+        label,
+        labelX,
+        labelY,
       });
     });
   } else if (mode === "package" && packageSubgraph && focusPackage) {

--- a/packages/web/src/viewer/views/graph.ts
+++ b/packages/web/src/viewer/views/graph.ts
@@ -363,6 +363,12 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
   const [dragState, setDragState] = useState<DragState | null>(null);
   const [focusHistory, setFocusHistory] = useState<string[]>([]);
   const [focusHistoryIndex, setFocusHistoryIndex] = useState(-1);
+  // Hover-to-spotlight state for the File Street View graph. Hovering an
+  // edge highlights it + its endpoints; hovering a node highlights every
+  // edge touching it. Lets the user trace "what connects to what" when many
+  // routes cross visually.
+  const [hoverEdgeKey, setHoverEdgeKey] = useState<string | null>(null);
+  const [hoverGraphNode, setHoverGraphNode] = useState<string | null>(null);
 
   useEffect(() => () => {
     if (hoverCloseTimerRef.current) clearTimeout(hoverCloseTimerRef.current);
@@ -1163,7 +1169,20 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
   const canGoBack = focusHistoryIndex > 0;
   const canGoForward = focusHistoryIndex >= 0 && focusHistoryIndex < focusHistory.length - 1;
 
-  const edgePaths: { d: string; cross: boolean; key: string; label?: string; labelX?: number; labelY?: number }[] = [];
+  const edgePaths: {
+    d: string;
+    cross: boolean;
+    key: string;
+    label?: string;
+    labelX?: number;
+    labelY?: number;
+    /** Source endpoint id (file path or pkg:NAME) — used for hover spotlight. */
+    fromId?: string;
+    /** Target endpoint id — used for hover spotlight. */
+    toId?: string;
+    /** Cross-zone pair label, if any — surfaced on hover even for non-rep edges. */
+    pairLabel?: string;
+  }[] = [];
   const kindOf = (id: string): NodeKind => nodeKindById.get(id) ?? "file";
 
   const svgW = svgDims.w;
@@ -1238,17 +1257,15 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
       let labelX: number | undefined = (a.x + b.x) / 2 + shift;
       let labelY: number | undefined = (a.y + b.y) / 2 - 8;
       let label: string | undefined;
-      if (isRep && zones && fromZone && toZone) {
-        label = `${zoneDisplayName(zones, fromZone)} → ${zoneDisplayName(zones, toZone)}${count > 1 ? ` ×${count}` : ""}`;
+      const pairLabel = cross && zones && fromZone && toZone
+        ? `${zoneDisplayName(zones, fromZone)} → ${zoneDisplayName(zones, toZone)}${count > 1 ? ` ×${count}` : ""}`
+        : undefined;
+      if (isRep && pairLabel) {
+        label = pairLabel;
         if (centroid && centroid.n > 0) {
           labelX = centroid.x / centroid.n;
           labelY = centroid.y / centroid.n - 8;
         }
-      } else if (cross) {
-        // Edges in a duplicated cross-zone group still get a position but no
-        // label string — keeps the existing structure for any consumer that
-        // expects labelX/labelY pairs on every cross edge.
-        label = undefined;
       }
       edgePaths.push({
         key: `${e.from}->${e.to}:${e.type}`,
@@ -1257,6 +1274,9 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
         label,
         labelX,
         labelY,
+        fromId: e.from,
+        toId: e.to,
+        pairLabel,
       });
     });
   } else if (mode === "package" && packageSubgraph && focusPackage) {
@@ -1272,12 +1292,43 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
           key: `${f}->${pkgId}`,
           d: elbowPath(fp.x + wFile, fp.y, pkgPos.x - wPkg, pkgPos.y),
           cross: false,
+          fromId: f,
+          toId: pkgId,
         });
       }
     }
   }
   const graphEdgeCount = edgePaths.length;
   const graphCrossEdgeCount = edgePaths.filter((edge) => edge.cross).length;
+
+  // ── Hover spotlight: derive which edges/nodes to highlight or dim based on
+  // the current hoverEdgeKey / hoverGraphNode. Hovering an edge spotlights
+  // that single edge + its two endpoints; hovering a node spotlights every
+  // edge touching that node + the connected nodes. Other edges/nodes go to
+  // a muted state so the spotlighted set reads clearly through the visual
+  // crossings. Computed inline so it's always in sync with the edgePaths /
+  // hover state pair without an additional memo.
+  const hoverActive = hoverEdgeKey !== null || hoverGraphNode !== null;
+  const activeEdgeKeys = new Set<string>();
+  const highlightedNodeIds = new Set<string>();
+  if (hoverGraphNode) {
+    highlightedNodeIds.add(hoverGraphNode);
+    for (const ep of edgePaths) {
+      if (ep.fromId === hoverGraphNode || ep.toId === hoverGraphNode) {
+        activeEdgeKeys.add(ep.key);
+        if (ep.fromId) highlightedNodeIds.add(ep.fromId);
+        if (ep.toId) highlightedNodeIds.add(ep.toId);
+      }
+    }
+  }
+  if (hoverEdgeKey) {
+    activeEdgeKeys.add(hoverEdgeKey);
+    const hovered = edgePaths.find((ep) => ep.key === hoverEdgeKey);
+    if (hovered) {
+      if (hovered.fromId) highlightedNodeIds.add(hovered.fromId);
+      if (hovered.toId) highlightedNodeIds.add(hovered.toId);
+    }
+  }
 
   return h("div", {
     ref: pageRef,
@@ -1336,7 +1387,9 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
               }),
             ),
             h("span", { class: "ig-mini-current" },
-              activeZone ? `${activeZone.name} · ${activeZoneInbound} in / ${activeZoneOutbound} out` : "All zones",
+              activeZone
+                ? `${activeZone.name} · ${activeZone.files.length}${inventory ? `/${inventory.files.length}` : ""} files · ${activeZoneInternalEdges} internal · ${activeZoneInbound} in / ${activeZoneOutbound} out`
+                : "All zones",
             ),
           ),
         h("div", { class: `ig-scope-card${activeZone ? " ig-scope-card-filtered" : ""}` },
@@ -1496,25 +1549,10 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
       h("section", { class: "ig-zone-overview ig-zone-minimap", "aria-label": activeZone ? `${activeZone.name} zone map` : "Zone map" },
         activeZone
           ? [
-              h("div", { class: "ig-zone-overview-head", key: "head" },
-                h("div", null,
-                  h("span", { class: "ig-zone-overview-kicker" }, "Zone map"),
-                  h("h3", null, activeZone.name),
-                ),
-                h("div", { class: "ig-zone-overview-stats" },
-                  // Show this zone's share of the project as X/Y so the user
-                  // can read both "how big is this zone" and "how big is the
-                  // codebase" at a glance, instead of just an unanchored
-                  // file count.
-                  h("span", null,
-                    inventory
-                      ? `${activeZone.files.length} / ${inventory.files.length} files`
-                      : `${activeZone.files.length} files`,
-                  ),
-                  h("span", null, `${activeZoneInternalEdges} internal imports`),
-                  h("span", null, `${activeZoneInbound} in / ${activeZoneOutbound} out`),
-                ),
-              ),
+              // Per-zone header removed: the zone name + file/import/in-out
+              // stats live in the scope-card up in the codebase-map section,
+              // so this view goes straight to the SVG to maximize map real
+              // estate and remove the redundancy.
               h("div", { class: "ig-zone-network", key: "network" },
                 h("svg", {
                   viewBox: `0 0 ${activeZoneNetworkW} ${activeZoneNetworkH}`,
@@ -1824,24 +1862,64 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
             ),
             h("g", { transform: `translate(${depView.x} ${depView.y}) scale(${depView.k})` },
               h("g", { class: "ig-edges" },
-                ...edgePaths.map((ep) =>
-                  h("path", {
+                ...edgePaths.map((ep) => {
+                  const isActive = activeEdgeKeys.has(ep.key);
+                  const dimmed = hoverActive && !isActive;
+                  const cls =
+                    `ig-edge${ep.cross ? " ig-edge-cross" : ""}` +
+                    (isActive ? " ig-edge-active" : "") +
+                    (dimmed ? " ig-edge-dim" : "");
+                  return h("g", {
                     key: ep.key,
-                    class: `ig-edge${ep.cross ? " ig-edge-cross" : ""}`,
-                    d: ep.d,
-                    "marker-end": "url(#ig-arrow)",
-                  }),
-                ),
+                    class: "ig-edge-group",
+                    onMouseEnter: () => setHoverEdgeKey(ep.key),
+                    onMouseLeave: () => setHoverEdgeKey((k) => (k === ep.key ? null : k)),
+                  },
+                    // Invisible wide hit target — makes the thin visible line
+                    // forgiving to hover with a mouse. Pointer events are
+                    // captured here; the visible path below stays
+                    // pointer-events:none via CSS so it doesn't steal hover.
+                    h("path", { class: "ig-edge-hit", d: ep.d }),
+                    h("path", {
+                      class: cls,
+                      d: ep.d,
+                      "marker-end": "url(#ig-arrow)",
+                    }),
+                  );
+                }),
               ),
               h("g", { class: "ig-edge-labels" },
-                ...edgePaths.filter((ep) => ep.label && ep.labelX !== undefined && ep.labelY !== undefined).map((ep) =>
-                  h("text", {
-                    key: `label-${ep.key}`,
-                    x: ep.labelX,
-                    y: ep.labelY,
-                    textAnchor: "middle",
-                  }, ep.label),
-                ),
+                ...edgePaths
+                  .filter((ep) => {
+                    if (ep.labelX === undefined || ep.labelY === undefined) return false;
+                    if (hoverEdgeKey) {
+                      // While hovering an edge, surface only THAT edge's
+                      // pair label — the others get out of the way so the
+                      // hovered connection reads cleanly.
+                      return ep.key === hoverEdgeKey && (ep.pairLabel ?? ep.label);
+                    }
+                    if (hoverGraphNode) {
+                      // While hovering a node, surface labels for every
+                      // edge touching it (rep or not), so the user sees
+                      // what each connection is.
+                      return activeEdgeKeys.has(ep.key) && (ep.pairLabel ?? ep.label);
+                    }
+                    // Default: representative cross-zone labels only.
+                    return Boolean(ep.label);
+                  })
+                  .map((ep) => {
+                    // When hovering, prefer the per-edge centroid (i.e. the
+                    // hovered edge's own midpoint) so the label sits over the
+                    // line the user is actually pointing at.
+                    const hovered = hoverEdgeKey === ep.key || (hoverGraphNode && activeEdgeKeys.has(ep.key));
+                    return h("text", {
+                      key: `label-${ep.key}`,
+                      class: `ig-edge-label${hovered ? " ig-edge-label-active" : ""}`,
+                      x: ep.labelX,
+                      y: ep.labelY,
+                      textAnchor: "middle",
+                    }, ep.pairLabel ?? ep.label);
+                  }),
               ),
               h("g", { class: "ig-nodes" },
                 ...(layoutNodes ?? []).map((n) => {
@@ -1857,11 +1935,22 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
                         : n.label;
                   const labelText = truncateNodeLabel(n.label, n.kind);
                   const contextText = n.kind === "file" ? truncateNodeLabel(parentContext(n.id), "file") : "";
+                  const isHovered = hoverGraphNode === n.id;
+                  const isHighlighted = highlightedNodeIds.has(n.id);
+                  const isDimmed = hoverActive && !isHighlighted;
                   return h("g", {
                     key: n.id,
-                    class: `ig-node ig-node-${n.kind}${isCenter ? " ig-node-center" : ""}${isSel ? " ig-node-selected" : ""}`,
+                    class:
+                      `ig-node ig-node-${n.kind}` +
+                      (isCenter ? " ig-node-center" : "") +
+                      (isSel ? " ig-node-selected" : "") +
+                      (isHovered ? " ig-node-hover" : "") +
+                      (isHighlighted && !isHovered ? " ig-node-related" : "") +
+                      (isDimmed ? " ig-node-dim" : ""),
                     transform: `translate(${pos.x - w / 2},${pos.y - hgt / 2})`,
                     title: tip,
+                    onMouseEnter: () => setHoverGraphNode(n.id),
+                    onMouseLeave: () => setHoverGraphNode((cur) => (cur === n.id ? null : cur)),
                     onPointerDown: (ev: PointerEvent) => {
                       ev.stopPropagation();
                       (ev.currentTarget as Element).setPointerCapture?.(ev.pointerId);

--- a/packages/web/src/viewer/views/graph.ts
+++ b/packages/web/src/viewer/views/graph.ts
@@ -1516,24 +1516,69 @@ export function Graph({ data, selectedFile, selectedZone, navigateTo }: GraphPro
         h("p", { class: "ig-kicker" }, activeZoneName ? "Map of Zone:" : "Map"),
         h("h2", { class: "ig-page-title" }, activeZoneName ? activeZoneName : "Codebase import map"),
       ),
-      h("div", { class: "ig-atlas-metrics", role: "list" },
-        h("div", { class: "ig-metric-tile", role: "listitem" },
-          h("span", { class: "ig-metric-value" }, fileCount.toLocaleString()),
-          h("span", { class: "ig-metric-label" }, "files"),
-        ),
-        h("div", { class: "ig-metric-tile", role: "listitem" },
-          h("span", { class: "ig-metric-value" }, summary.totalEdges.toLocaleString()),
-          h("span", { class: "ig-metric-label" }, "imports"),
-        ),
-        h("div", { class: "ig-metric-tile", role: "listitem" },
-          h("span", { class: "ig-metric-value" }, summary.totalExternal.toLocaleString()),
-          h("span", { class: "ig-metric-label" }, "packages"),
-        ),
-        h("div", { class: "ig-metric-tile", role: "listitem" },
-          h("span", { class: "ig-metric-value" }, zones ? zones.zones.length.toLocaleString() : "—"),
-          h("span", { class: "ig-metric-label" }, "zones"),
-        ),
-      ),
+      (() => {
+        if (activeZone && activeZoneFiles) {
+          // ── Per-zone metrics ──
+          // When a zone is selected, swap the project-total tiles for
+          // zone-scoped numbers so the hero stops misrepresenting "I'm zoomed
+          // into UI Overlays but the headline is still 102 project files".
+          // The neighbor-zone count covers both inbound and outbound
+          // partners; the package count is external imports touched by any
+          // file in this zone.
+          const zonePackages = imports
+            ? imports.external.filter((ext) => ext.importedBy.some((p) => activeZoneFiles.has(p))).length
+            : 0;
+          const neighborZoneIds = new Set<string>();
+          if (zones) {
+            for (const edge of imports?.edges ?? []) {
+              const fromIn = activeZoneFiles.has(edge.from);
+              const toIn = activeZoneFiles.has(edge.to);
+              if (fromIn === toIn) continue;
+              const otherFile = fromIn ? edge.to : edge.from;
+              const otherZone = fileToZoneId(otherFile, zones);
+              if (otherZone && otherZone !== activeZone.id) neighborZoneIds.add(otherZone);
+            }
+          }
+          return h("div", { class: "ig-atlas-metrics ig-atlas-metrics-zone", role: "list" },
+            h("div", { class: "ig-metric-tile", role: "listitem" },
+              h("span", { class: "ig-metric-value" },
+                `${activeZone.files.length.toLocaleString()}/${fileCount.toLocaleString()}`,
+              ),
+              h("span", { class: "ig-metric-label" }, "zone files"),
+            ),
+            h("div", { class: "ig-metric-tile", role: "listitem" },
+              h("span", { class: "ig-metric-value" }, activeZoneInternalEdges.toLocaleString()),
+              h("span", { class: "ig-metric-label" }, "internal imports"),
+            ),
+            h("div", { class: "ig-metric-tile", role: "listitem" },
+              h("span", { class: "ig-metric-value" }, zonePackages.toLocaleString()),
+              h("span", { class: "ig-metric-label" }, "packages used"),
+            ),
+            h("div", { class: "ig-metric-tile", role: "listitem" },
+              h("span", { class: "ig-metric-value" }, neighborZoneIds.size.toLocaleString()),
+              h("span", { class: "ig-metric-label" }, "neighbor zones"),
+            ),
+          );
+        }
+        return h("div", { class: "ig-atlas-metrics", role: "list" },
+          h("div", { class: "ig-metric-tile", role: "listitem" },
+            h("span", { class: "ig-metric-value" }, fileCount.toLocaleString()),
+            h("span", { class: "ig-metric-label" }, "files"),
+          ),
+          h("div", { class: "ig-metric-tile", role: "listitem" },
+            h("span", { class: "ig-metric-value" }, summary.totalEdges.toLocaleString()),
+            h("span", { class: "ig-metric-label" }, "imports"),
+          ),
+          h("div", { class: "ig-metric-tile", role: "listitem" },
+            h("span", { class: "ig-metric-value" }, summary.totalExternal.toLocaleString()),
+            h("span", { class: "ig-metric-label" }, "packages"),
+          ),
+          h("div", { class: "ig-metric-tile", role: "listitem" },
+            h("span", { class: "ig-metric-value" }, zones ? zones.zones.length.toLocaleString() : "—"),
+            h("span", { class: "ig-metric-label" }, "zones"),
+          ),
+        );
+      })(),
       activeZoneName
         ? null
         : h("div", { class: "ig-atlas-footer" },

--- a/packages/web/tests/unit/viewer/graph-view.test.ts
+++ b/packages/web/tests/unit/viewer/graph-view.test.ts
@@ -137,8 +137,11 @@ describe("Graph (Import Graph view)", () => {
       expect(root.querySelector(".ig-focus-detail")?.textContent).toContain("Driven by zone: Zone B");
     });
     expect(root.querySelector(".ig-codebase-mini")?.textContent).toContain("Zone B");
-    expect(root.querySelector(".ig-zone-overview")?.textContent).toContain("Zone B");
-    expect(root.querySelector(".ig-zone-overview-kicker")?.textContent).toContain("Zone map");
+    // The per-zone "Map of Zone" header is now the page-level atlas hero —
+    // the redundant in-panel header was removed and the active zone name
+    // lives in the hero h2 above. The .ig-zone-overview-kicker selector is
+    // gone with the header; if you need it back, restore the per-zone head.
+    expect(root.querySelector(".ig-atlas-hero")?.textContent).toContain("Zone B");
     expect(root.textContent).toContain("Map of Zone:");
     expect(root.textContent).not.toContain("Filtered to Zone B");
     expect(onSelect).not.toHaveBeenCalled();
@@ -163,7 +166,8 @@ describe("Graph (Import Graph view)", () => {
     root.querySelector(".ig-page")?.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: -20 }));
     await vi.waitFor(() => {
       expect(root.querySelector(".ig-codebase-morph")?.className).toContain("ig-codebase-morph-full");
-      expect(root.querySelector(".ig-zone-overview")?.textContent).toContain("Zone A");
+      // Zone name lives in the atlas hero now, not the in-panel header.
+      expect(root.querySelector(".ig-atlas-hero")?.textContent).toContain("Zone A");
     });
     root.querySelector(".ig-page")?.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: 20 }));
     await vi.waitFor(() => {
@@ -226,9 +230,13 @@ describe("Graph (Import Graph view)", () => {
     (root.querySelector(".ig-zone-network-node") as SVGGElement).dispatchEvent(new Event("pointerenter", { bubbles: true }));
     await vi.waitFor(() => {
       expect(root.querySelector(".ig-zone-network-edge-external path")).not.toBeNull();
+      // Zone B appears here as an external-zone label inside the zone SVG —
+      // this assertion is about the OTHER zone surfacing on hover, not the
+      // active zone (which is Zone A and lives in the atlas hero h2).
       expect(root.querySelector(".ig-zone-overview")?.textContent).toContain("Zone B");
       expect(root.querySelector(".ig-graph-scope")?.textContent).toContain("cross-boundary");
-      expect(root.querySelector(".ig-edge-labels")?.textContent).toContain("Zone A -> Zone B");
+      // Edge labels now use a Unicode arrow.
+      expect(root.querySelector(".ig-edge-labels")?.textContent).toContain("Zone A → Zone B");
     });
   });
 


### PR DESCRIPTION
## Summary

  A broad sourcevision/analyzer + viewer/UX pass driven by feedback from running n-dx on a real Swift codebase. All bumps are `patch` — no API breaks.

  ### Sourcevision analyzer
  - **Swift support end-to-end.** New language registry entry, top-of-file import parser, project-wide symbol-reference resolver, `swift test` /
  instead of file-tree proximity noise.
  - **Context-graph primitives.** Optional `ImportEdge.weight` (Louvain prefers it), `Finding.anchors[]`, `Zone.confidence/evidenceSources`, and
  `.sourcevision/project-profile.json` (primary language, frameworks, release infra, build/CI surfaces). All optional — strict superset, no resolver-side
  breaks.
  - **Smarter clustering.** Reference-count edge weighting (Swift + TS/JS) with a per-edge cap, test quarantine for out-of-package tests (Swift `Tests/`
  layout) while keeping colocated tests (Go `_test.go`) with their package, project-relative subdivision threshold.
  - **Cheaper + faster enrichment.** Skip the LLM entirely on structural-only zones (build scripts, assets, docs, config). Pass 1 (naming-dominant) uses the
   light-tier model (Haiku); pass 2+ stays on the standard model for analytical work. Parallel batches inside a pass. `--full` converges-and-exits instead
  of running to pass 4 unconditionally.
  - **Prompt-side guards.** Project shape (frameworks, release infra, language) fed into the finding prompt with hard anti-recommendations — no more
  MVVM-on-SwiftUI suggestions, no more "introduce a VERSION file" when release-please is wired, no "if X then Y" hypotheticals.

  ### Rex
  - Hash-addressable acknowledgements (`--acknowledge=h1,h2`), `--unacknowledge`, `--reason=<category>`, and `--accept=hashes:…` partial-accept inside
  recommendation groups.

  ### Hench
  - Swift guard profile (`allowedCommands: swift/make/xcodebuild/xcrun/git`, Xcode build-time-friendly timeouts). `autoDetectTestCommand` prefers a Makefile
   `validate` target, then language-aware fallbacks for Swift/Rust/Go/Python.

  ### Web viewer
  - Tasks view: two-row control bar, single bounded scroll, multi-select status dropdown with smart defaults, collapsed by default. Quick Add now persists
  `acceptanceCriteria`; Start Task launches a hench run instead of just flipping status. Hench Runs leads with run history; operational panels tucked into a
   collapsed "System status" drawer with the previously-unstyled WebSocket panel now styled.
  - Graph view: zone-scoped hero metrics when a zone is active, side-by-side layout on wide screens (≥1100 px), hover spotlight in File Street View (hover
  an edge or node, others mute), deduped cross-zone edge labels, focused-file path shown next to the FILE STREET VIEW header.
  - Finding cards: killed the orange-wash + left-bar pattern. Neutral cards with severity expressed as a small color-keyed icon + small-caps label.

  ## Test plan
  - [ ] `pnpm test` passes (it does as of push).
  - [ ] `sv analyze .` on a Swift repo — verify zones partition meaningfully, tests get their own zone, AppEnvironment lands in app-shell (not core).
  - [ ] `sv analyze --full .` — verify early-exit log fires on a no-op pass, pass 1 uses Haiku.
  - [ ] `rex recommend .` — verify findings print with `[xxxxxx]` hash IDs.
  - [ ] Open the Architecture page — verify finding cards have no orange wash and no left bar.