### PR TITLE
fix(changesets): use @n-dx/rex package name

### DIFF
--- a/.changeset/rex-accept-hashes-mode.md
+++ b/.changeset/rex-accept-hashes-mode.md
@@ -1,5 +1,5 @@
 ---
-"rex": patch
+"@n-dx/rex": patch
 ---
 
 Allow partial accept inside a recommendation group via

--- a/.changeset/rex-ack-hash-undo-reason.md
+++ b/.changeset/rex-ack-hash-undo-reason.md
@@ -1,5 +1,5 @@
 ---
-"rex": patch
+"@n-dx/rex": patch
 ---
 
 Make `rex recommend` acknowledgement workflow address-by-hash. Each finding


### PR DESCRIPTION
## Summary
- Two changesets (`rex-accept-hashes-mode.md`, `rex-ack-hash-undo-reason.md`) referenced the package as `"rex"` instead of `"@n-dx/rex"`, breaking the post-#224 Release workflow with `Found changeset … for package rex which is not in the workspace`.
- Updates both to the correct workspace package name so `changeset version` succeeds on the next Release run.

Failing run: https://github.com/en-dash-consulting/n-dx/actions/runs/26576200022/job/78296063903

## Test plan
- [ ] Re-run Release workflow on main after merge and confirm the version PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)