### PR TITLE
fix(changesets): rename sourcevision package + validate changesets in CI

### DIFF
--- a/.changeset/sv-cheaper-enrichment.md
+++ b/.changeset/sv-cheaper-enrichment.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Cut enrichment LLM cost and wall-clock without quality regression.

--- a/.changeset/sv-context-graph-primitives.md
+++ b/.changeset/sv-context-graph-primitives.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Phase 0 of the context-graph rework: introduces three foundational primitives

--- a/.changeset/sv-edge-weight-by-references.md
+++ b/.changeset/sv-edge-weight-by-references.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Zone clustering now uses an explicit edge-weight model. `ImportEdge` gained an

--- a/.changeset/sv-faster-analyze.md
+++ b/.changeset/sv-faster-analyze.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 "@n-dx/llm-client": patch
 ---
 

--- a/.changeset/sv-headers-and-speculative-filter.md
+++ b/.changeset/sv-headers-and-speculative-filter.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Stop fabricating findings against documented files. The enrichment prompt now

--- a/.changeset/sv-jsts-edge-weight.md
+++ b/.changeset/sv-jsts-edge-weight.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Extend the reference-count edge-weight model to JS/TS imports. The resolver

--- a/.changeset/sv-project-shape-prompt.md
+++ b/.changeset/sv-project-shape-prompt.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Feed the detected project profile into the LLM finding prompt with hard

--- a/.changeset/sv-swift-import-resolver.md
+++ b/.changeset/sv-swift-import-resolver.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Add a Swift import + symbol-reference resolver so sourcevision produces a real

--- a/.changeset/sv-swift-language-registry.md
+++ b/.changeset/sv-swift-language-registry.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Register Swift as a first-class language in the language registry so `.swift`

--- a/.changeset/sv-test-quarantine-and-subdivision.md
+++ b/.changeset/sv-test-quarantine-and-subdivision.md
@@ -1,5 +1,5 @@
 ---
-"sourcevision": patch
+"@n-dx/sourcevision": patch
 ---
 
 Two complementary partitioning fixes that target the "29-file blob with three

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
             exit 1
           fi
 
+      - name: Validate changesets
+        # Validates every changeset's front matter against the workspace
+        # (catches stale package names like "rex" vs "@n-dx/rex" that would
+        # otherwise only fail in the Release workflow after merge to main).
+        run: pnpm exec changeset status
+
   smoke-macos:
     name: CLI Smoke (macOS)
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,9 @@ jobs:
         # Validates every changeset's front matter against the workspace
         # (catches stale package names like "rex" vs "@n-dx/rex" that would
         # otherwise only fail in the Release workflow after merge to main).
-        run: pnpm exec changeset status
+        # --since=origin/main is required because PR checkouts are detached
+        # HEAD with no local "main" branch for changeset to diff against.
+        run: pnpm exec changeset status --since=origin/main
 
   smoke-macos:
     name: CLI Smoke (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # changeset status compares against main to compute the release plan
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5


### PR DESCRIPTION
## Summary
- Ten changesets referenced `"sourcevision"` instead of `"@n-dx/sourcevision"`, breaking the Release run on `777240b` ([failed run](https://github.com/en-dash-consulting/n-dx/actions/runs/26578330003/job/78301969167)) — same class of bug as #225.
- Adds `pnpm exec changeset status` as a PR-validation step. It parses every changeset's front matter against the actual workspace, so a stale or malformed package name fails on the PR instead of on `main`'s Release run.

## Why this slipped through twice
The existing "Require changeset" step only checked for file existence, not validity. Now CI runs the same release-plan assembler that the publish workflow does, so the two cannot diverge.

## Test plan
- [ ] CI on this PR is green (the new "Validate changesets" step passes after the renames).
- [ ] After merge, re-run the Release workflow and confirm the version PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)