### PR TITLE
ci: switch npm publishing to Trusted Publisher (OIDC)

### DIFF
--- a/.changeset/npm-trusted-publishing.md
+++ b/.changeset/npm-trusted-publishing.md
@@ -1,0 +1,6 @@
+---
+---
+
+ci: switch npm publishing to Trusted Publisher (OIDC) — replaces the
+NPM_TOKEN-based publish with short-lived GitHub OIDC credentials and
+upgrades npm to 11.x so provenance attestation works on Node 22.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@
 # 2. The "Version Packages" PR is auto-created/updated with bumped versions + changelog
 # 3. Merging the "Version Packages" PR triggers npm publish + git tags
 #
-# Requires NPM_TOKEN secret (granular access token scoped to @n-dx/*).
-# Create at npmjs.com → Access Tokens → Granular Access Token.
+# Publishes via npm Trusted Publishing (OIDC) — no long-lived token. Each
+# @n-dx/* package must have a Trusted Publisher configured at npmjs.com
+# pointing at this workflow (en-dash-consulting/n-dx, release.yml,
+# environment "npm"). Trusted publisher config is per-package, not per-scope.
 
 name: Release
 
@@ -34,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -42,6 +44,11 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for Trusted Publishing
+        # OIDC trusted publishing and provenance attestation require npm
+        # >= 11.5.1. Node 22 ships with npm 10.x by default.
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -65,5 +72,8 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NODE_AUTH_TOKEN — auth comes from GitHub OIDC. id-token: write
+          # above grants the runner permission to mint the OIDC token that
+          # pnpm/npm exchange with the registry for a short-lived publish
+          # credential.
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Drops `NPM_TOKEN` from the publish step in favor of [npm Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers): GitHub Actions mints a short-lived credential per run, the registry verifies the OIDC token against the configured Trusted Publisher, and the secret never has to be rotated.
- Adds an `npm install -g npm@latest` step. Trusted publishing + provenance attestation requires npm ≥ 11.5.1; Node 22 ships with npm 10.x.
- Bumps `pnpm/action-setup@v4` → `v5` to match `ci.yml`.
- The Release run failure caused by `NPM_TOKEN` returning 404 should be resolved once npm-side Trusted Publisher config is in place for **all six** `@n-dx/*` packages (it's per-package, not per-scope).

## Required npm-side configuration
Each package below needs a Trusted Publisher at https://npmjs.com/package/<pkg>/access pointing at:
- Organization: `en-dash-consulting`
- Repository: `n-dx`
- Workflow filename: `release.yml`
- Environment: `npm`

Packages:
- [ ] `@n-dx/core`
- [ ] `@n-dx/rex`
- [ ] `@n-dx/sourcevision`
- [ ] `@n-dx/hench`
- [ ] `@n-dx/llm-client`
- [ ] `@n-dx/web`

## Test plan
- [ ] CI on this PR is green.
- [ ] Confirm all six packages have Trusted Publisher configured.
- [ ] Merge to main. The Release run will trigger and should publish 0.4.2 (already bumped on main by #227 but never published due to the token failure).
- [ ] Verify on npmjs.com that all six show 0.4.2 with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)