### PR TITLE
chore: republish all packages as 0.4.3 via OIDC

### DIFF
--- a/.changeset/npm-trusted-publishing.md
+++ b/.changeset/npm-trusted-publishing.md
@@ -1,6 +1,0 @@
----
----
-
-ci: switch npm publishing to Trusted Publisher (OIDC) — replaces the
-NPM_TOKEN-based publish with short-lived GitHub OIDC credentials and
-upgrades npm to 11.x so provenance attestation works on Node 22.

--- a/.changeset/republish-via-oidc.md
+++ b/.changeset/republish-via-oidc.md
@@ -1,0 +1,14 @@
+---
+"@n-dx/core": patch
+"@n-dx/hench": patch
+"@n-dx/llm-client": patch
+"@n-dx/rex": patch
+"@n-dx/sourcevision": patch
+"@n-dx/web": patch
+---
+
+Republish via npm Trusted Publishing. 0.4.2 was bumped in source but never
+made it to the registry because the original NPM_TOKEN-based publish in
+the Release run for #227 returned E404. Workflow now uses OIDC; this
+changeset moves all six packages to 0.4.3 so they get published with
+provenance attestation.


### PR DESCRIPTION
## Summary
0.4.2 was bumped in source by #227 but never made it to npm — the Release run for that merge hit `E404 Not Found` because the `NPM_TOKEN` auth had broken. #228 swapped the publish path to npm Trusted Publishing (OIDC), but the Release run that followed exited at `All changesets are empty; not creating PR` because the only remaining changeset was the empty marker I added so #228 could pass CI's require-changeset rule.

This PR moves us forward by skipping 0.4.2 on the registry:
- Bumps all six `@n-dx/*` packages from 0.4.2 → 0.4.3 via a real changeset.
- Deletes `.changeset/npm-trusted-publishing.md` (the empty marker).

0.4.2 lives in git history (tags + main's package.json before the next version run) but won't appear on npm. Going forward, npm sees a clean jump from 0.4.1 to 0.4.3.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge, changesets/action opens a "Version Packages" PR bumping all six to 0.4.3.
- [ ] Merge that PR → Release runs publish via OIDC → all six packages land on npm at 0.4.3 with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)