### PR TITLE
fix: remove malformed min-release-age=3d from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,11 @@
 link-workspace-packages=true
 prefer-workspace-packages=true
 ignore-scripts=true
+# Supply-chain age window for installs is configured for pnpm in
+# pnpm-workspace.yaml (`minimumReleaseAge: 4320` minutes). The previous
+# `min-release-age=3d` line was a malformed npm-style duplicate: npm
+# 11.x expects a Number (days), so "3d" failed config validation and
+# propagated an Invalid Date into pacote's Fetcher, crashing every
+# `npm info` call with "Invalid time value" — including the one
+# changesets runs during `pnpm exec changeset publish`.
 minimum-release-age=4320
-min-release-age=3d


### PR DESCRIPTION
## Summary
The `.npmrc` had two release-age settings:

\`\`\`
minimum-release-age=4320   # pnpm-style, valid (minutes)
min-release-age=3d         # npm-style, MALFORMED
\`\`\`

npm 11.x defines `min-release-age` as `[null, Number]` (in days). The string `"3d"` failed type validation **but still propagated downstream** into `pacote`'s `FetcherBase` constructor, where it became an Invalid Date. Every later `toISOString()` call on it threw `RangeError: Invalid time value`.

This is the actual root cause of the last several failed Release runs ([latest](https://github.com/en-dash-consulting/n-dx/actions/runs/26641256131)) — `changeset publish` calls `npm info <pkg>` per package before publishing to detect what's already on the registry, and the first call crashes.

Verified locally with npm 11.15.0:

\`\`\`
$ npx -y npm@11.15.0 info @n-dx/llm-client name version --json
{ "name": "@n-dx/llm-client", "version": "0.4.1" }
\`\`\`

Supply-chain age protection for installs is still enforced via `minimumReleaseAge: 4320` in `pnpm-workspace.yaml`. The redundant npm-side knob isn't needed in this repo since publish goes through `pnpm publish`, not `npm publish`.

## Test plan
- [ ] CI passes (no changeset needed — `.npmrc` is outside `packages/`, the loosened rule from #231 covers this).
- [ ] After merge, Release runs `npm info` cleanly, then `pnpm publish` proceeds and publishes 0.4.3 via OIDC trusted publishing (validated end-to-end in #231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)