### PR TITLE
fix(tests): repair root test-suite failures and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
       - name: Run unit tests
         run: pnpm -r run test
 
+      # Root-level e2e / integration / gauntlet suites live in tests/** and are
+      # NOT covered by `pnpm -r run test` (which only runs per-package tests).
+      # The bind-aware runner excludes the LLM-spend sourcevision eval gate
+      # (run separately via `pnpm gauntlet:evals`) and any loopback-bind suites
+      # when the runner can't bind a local socket.
+      - name: Run root e2e / integration tests
+        run: node scripts/run-vitest-bind-aware.mjs root
+
       - name: Require changeset
         # Skip on the Changesets release PR: that PR's whole purpose is
         # to consume the changesets, so the directory is empty by design.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "validate": "pnpm -r run validate",
     "verify": "pnpm security:obfuscation && vitest run tests/e2e && node packages/core/ci.js .",
     "security:obfuscation": "node scripts/check-obfuscated-code.mjs",
-    "gauntlet": "vitest run tests/gauntlet --exclude tests/gauntlet/sourcevision-evals/evals.test.js",
+    "gauntlet": "vitest run tests/gauntlet --exclude '**/sourcevision-evals/evals.test.js'",
     "gauntlet:evals": "vitest run tests/gauntlet/sourcevision-evals/evals.test.js",
     "gauntlet:evals:record": "node tests/gauntlet/sourcevision-evals/record-goldens.js",
     "pr-check": "node pr-check.js",

--- a/scripts/run-vitest-bind-aware.mjs
+++ b/scripts/run-vitest-bind-aware.mjs
@@ -50,9 +50,11 @@ const vitestArgs = ["run", ...passthroughArgs];
 
 // The sourcevision eval gate makes real LLM calls and is documented to run only
 // via `pnpm gauntlet:evals` (it is also excluded from `pnpm gauntlet`). Keep it
-// out of the default `pnpm test` gate.
+// out of the default `pnpm test` gate. The pattern must be a glob — vitest's
+// `--exclude` matches globs against absolute paths, so a bare relative path
+// (no `**/` prefix) silently fails to match and the suite runs anyway.
 if (profile === "root") {
-  vitestArgs.push("--exclude", "tests/gauntlet/sourcevision-evals/evals.test.js");
+  vitestArgs.push("--exclude", "**/sourcevision-evals/evals.test.js");
 }
 
 if (!bindAvailable) {

--- a/tests/e2e/published-package-loadability.test.js
+++ b/tests/e2e/published-package-loadability.test.js
@@ -42,6 +42,21 @@ function listPublishablePackages() {
     .filter(Boolean);
 }
 
+// `npm pack --json` is documented to print only a JSON array, but some npm
+// versions still run the package's `prepack`/`prepare` (build) lifecycle even
+// with `--ignore-scripts`, prepending a build banner to stdout (e.g.
+// "> @n-dx/web@x build\nBuilt viewer: ..."). Parse from the first `[` so the
+// test is robust to that preamble regardless of the local npm version.
+function parseNpmPackReport(out) {
+  const start = out.indexOf("[");
+  if (start === -1) {
+    throw new Error(
+      `npm pack --json produced no JSON array:\n${out.slice(0, 500)}`,
+    );
+  }
+  return JSON.parse(out.slice(start));
+}
+
 function packAndExtract(pkgDir) {
   const tmpRoot = mkdtempSync(join(tmpdir(), "ndx-pack-load-"));
 
@@ -53,7 +68,7 @@ function packAndExtract(pkgDir) {
     ["pack", "--json", "--ignore-scripts", "--pack-destination", tmpRoot],
     { cwd: pkgDir, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
   );
-  const [report] = JSON.parse(out);
+  const [report] = parseNpmPackReport(out);
   const tgzPath = join(tmpRoot, report.filename);
 
   const extractDir = join(tmpRoot, "extracted");


### PR DESCRIPTION
The root tests/** suite (e2e, gauntlet) had three failures that went unnoticed because CI only ran `pnpm -r run test` (per-package), never the root suite. All trace back to one real bug plus an npm-version quirk:

- Broken vitest --exclude glob. The sourcevision eval gate is documented to run only via `pnpm gauntlet:evals`, but the exclude was a bare relative path. vitest matches --exclude globs against absolute paths, so it never matched: the gate ran in `pnpm test`, failed its 1.0 floor, AND starved the CLI-spawning cli-refresh e2e tests of CPU until they hit the 30s timeout. Fixed the glob (`**/sourcevision-evals/evals.test.js`) in both the bind-aware runner and the `gauntlet` script. With the gate excluded, the cli-refresh timeouts vanish (a single refresh is ~0.5s — contention, not slow work).

- published-package-loadability parsed `npm pack --json` assuming pure-JSON stdout, but some npm versions run prepack/build even with --ignore-scripts and prepend a banner. Parse from the first `[` instead.

Then gate the root suite in CI so this can't silently rot again: a new "Run root e2e / integration tests" step runs the same suite developers run via `pnpm test`. This also covers the "Required" tests named in CLAUDE.md (cli-dev, scheduler-startup), previously ungated.

Verified: full `pnpm test` is green (exit 0; root 1761 + per-package ~12.4k).

NOTE: a fork PR's pull_request checks run the BASE branch's workflow, not the PR's, so the new CI step is NOT exercised by this PR's own checks — its first real run is the post-merge push to main. Watch that run. (Server e2e tests use ephemeral ports, so parallel workers won't collide.)

Separate follow-up: `pnpm gauntlet:evals` still fails its 1.0 zone floor (0.388) because the medium-app golden, recorded in April (#174), drifted from current zone output. That lane is LLM-spend and not CI-gated; re-recording the golden is a deliberate sourcevision-team call.