### PR TITLE
fix(windows): npm shell resolution in tests + Codex prompt via stdin

### DIFF
--- a/.changeset/fix-codex-windows-prompt.md
+++ b/.changeset/fix-codex-windows-prompt.md
@@ -1,0 +1,5 @@
+---
+"@n-dx/llm-client": patch
+---
+
+Fix Codex CLI provider on Windows: pass prompt via stdin instead of argv. On Windows, `shell: true` routes through cmd.exe which splits unquoted multi-word arguments on spaces, causing Codex to receive a fragmented prompt. Passing `-` as the prompt argument and writing to `proc.stdin` bypasses cmd.exe argument parsing.

--- a/.changeset/fix-pnpm-shell-windows-ci.md
+++ b/.changeset/fix-pnpm-shell-windows-ci.md
@@ -1,0 +1,5 @@
+---
+"@n-dx/core": patch
+---
+
+Fix `ndx ci` on Windows: pnpm is a `.cmd` shim and requires `shell: true` to resolve without ENOENT. Add `shell: process.platform === "win32"` to the docs-build spawn in `ci.js`.

--- a/packages/core/ci.js
+++ b/packages/core/ci.js
@@ -128,7 +128,7 @@ async function runDocsPhase(dir, info, isJSON, spawnTracked) {
   // Step 0c: docs build
   info("── docs build ──");
   const docsBuild = await new Promise((res) => {
-    const child = spawnTracked("pnpm", ["docs:build"], { cwd: dir, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawnTracked("pnpm", ["docs:build"], { cwd: dir, stdio: ["ignore", "pipe", "pipe"], shell: process.platform === "win32" });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d) => { stdout += d; });

--- a/packages/llm-client/src/codex-cli-provider.ts
+++ b/packages/llm-client/src/codex-cli-provider.ts
@@ -201,17 +201,20 @@ async function spawnOnce(
       "-o",
       outputPath,
       ...(request.cliFlags ?? []),
-      request.prompt,
+      "-",
     ];
     debugLog(`spawn start cli="${cliBinary}" model="${request.model || resolveCodexModel(codexConfig)}" promptChars=${request.prompt.length}`);
     debugLog(`spawn args: ${JSON.stringify(args)}`);
 
     await new Promise<void>((resolve, reject) => {
       const proc = spawn(cliBinary, args, {
-        stdio: ["ignore", "ignore", "pipe"],
+        stdio: ["pipe", "ignore", "pipe"],
         env: envOverride ?? process.env,
         shell: process.platform === "win32",
       });
+
+      proc.stdin.write(request.prompt);
+      proc.stdin.end();
 
       let stderr = "";
       let timeoutId: NodeJS.Timeout | undefined;

--- a/packages/llm-client/tests/unit/codex-output-validation.test.ts
+++ b/packages/llm-client/tests/unit/codex-output-validation.test.ts
@@ -44,9 +44,11 @@ function mockProcess(exitCode: number) {
   const proc = new EventEmitter() as EventEmitter & {
     stderr: Readable;
     stdout: null;
+    stdin: { write: () => void; end: () => void };
   };
   proc.stderr = new EventEmitter() as unknown as Readable;
   proc.stdout = null;
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
   process.nextTick(() => proc.emit("close", exitCode));
   return proc;
 }

--- a/tests/e2e/published-imports-resolved.test.js
+++ b/tests/e2e/published-imports-resolved.test.js
@@ -56,6 +56,7 @@ function getPackedFiles(pkgDir) {
     cwd: pkgDir,
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "ignore"],
+    shell: true,
   });
   const jsonStart = out.indexOf("[");
   if (jsonStart === -1) {


### PR DESCRIPTION
## Summary

Two Windows compatibility fixes:

- **`fix(tests)`** — `execFileSync("npm")` fails on Windows with ENOENT because npm is a `.cmd` shim. Adding `shell: true` lets the OS resolve it cross-platform.
- **`fix(llm-client)`** — Codex provider was passing the prompt as the final argv element. On Windows, `shell: true` routes through cmd.exe which splits unquoted multi-word arguments on spaces, causing Codex to throw an unexpected argument error. Passing `"-"` and writing to `proc.stdin` bypasses cmd.exe argument parsing entirely — matching how the Claude provider already handles this.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [ ] Verify Codex prompt delivery on Windows with a real `ndx work` run

## Related

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)