### PR TITLE
Fix/correct windows install hal

### DIFF
--- a/.changeset/update-notice-install-manager.md
+++ b/.changeset/update-notice-install-manager.md
@@ -1,0 +1,12 @@
+---
+"@n-dx/core": patch
+---
+
+The "Update available" notice now suggests an upgrade command that actually works.
+
+Previously it always printed `npm i -g @n-dx/core`, regardless of how the copy was installed, which failed two ways:
+
+- **Wrong package manager.** A pnpm-global user following `npm i -g` ends up with a second global install under the npm prefix. Both ship an `ndx` shim, and whichever resolves first on `PATH` wins — so `ndx --version` can keep reporting the old version even though the upgrade "succeeded". `update-check.js` now infers the installing manager from its own path on disk (pnpm's `.pnpm` virtual store, yarn's data directory, else npm) and prints the matching `pnpm add -g` / `yarn global add` / `npm i -g` form.
+- **Missing `@latest`.** pnpm records a caret range in its global manifest, and for 0.x versions `^0.3.1` means `>=0.3.1 <0.4.0`. A bare `pnpm add -g @n-dx/core` or `pnpm update -g` re-resolves inside that range and can never cross a minor boundary, leaving users stranded on an old line indefinitely. The suggested command now always pins `@n-dx/core@latest`.
+
+Adds a `docs/guide/troubleshooting.md` entry for the `ERR_MODULE_NOT_FOUND … assistant-assets/index.js` crash that 0.3.x installs hit, since that failure occurs while Node links the module graph — before any `ndx` code can run and surface an update notice. Documents the upgrade-pinning rule in the README install section.

--- a/.changeset/win-bare-binary-pathext.md
+++ b/.changeset/win-bare-binary-pathext.md
@@ -1,0 +1,6 @@
+---
+"@n-dx/llm-client": patch
+"@n-dx/core": patch
+---
+
+Stop quoting bare command names in the Windows cmd.exe verbatim command line so PATHEXT resolution still applies. `buildWindowsCliCommandLine` quoted every token including the binary, and a quoted command name makes cmd.exe look for an exact filename match on PATH instead of trying `.CMD`/`.EXE`/… in turn. When a PATH directory holds an extensionless file beside its shim — exactly what pnpm/npm global installs produce (`pnpm` + `pnpm.CMD`, `claude` + `claude.CMD`) — cmd found the extensionless POSIX script, failed `CreateProcess`, and exited 1 with `The system cannot find the path specified.`, making the CLI look absent on Windows. Arguments are still quoted unconditionally and binary paths containing spaces or metacharacters keep their quotes, so the GH #68 spaced-path handling is unchanged. Non-Windows platforms are unaffected — they use a plain `spawn` and never build a cmd.exe command line.

--- a/.changeset/windows-snapshot-rollback.md
+++ b/.changeset/windows-snapshot-rollback.md
@@ -1,0 +1,15 @@
+---
+"@n-dx/rex": patch
+---
+
+Fix the PRD rollback snapshot on Windows, and add `rex restore` to use it.
+
+**The bug.** `snapshotPRDTree` named its backup directory `prd_tree_<raw ISO-8601 timestamp>`. ISO-8601 puts colons in the time component (`2026-08-05T17:27:18.959Z`), and `:` is illegal in Windows filenames — reserved for drive letters and NTFS alternate data streams. So the snapshot `mkdir`/`cp` failed with `EINVAL` on **every** Windows invocation. Because `add` and `reshape` caught the failure, printed a one-line warning, and continued anyway, Windows users had been running destructive tree rewrites with no rollback point at all — and the only signal was a line of text above the normal command output. Snapshot ids are now colon-free (`2026-08-05T17-27-18.959Z`), encoded positionally so lexicographic order still equals chronological order, which `getAvailableBackups` depends on.
+
+**Restore was also broken.** `restoreFromBackup` documented "Remove current tree if it exists" but performed a recursive copy with `force: true` — an overlay, not a replace. Any file a command created after the snapshot survived the "rollback", leaving a tree that was the union of both states rather than the point in time it claimed to be. Restore now stages the snapshot beside the live tree and swaps it in, so a partial failure can never leave the project with no PRD.
+
+**Snapshots are now reachable.** Added `rex restore`: lists available snapshots with timestamps and file counts, restores via `--latest` or `--id=<id>`, and confirms before replacing the tree (`--yes` to skip, `--format=json` for scripts). Previously the snapshots existed on disk with no supported way to use them, and the failure hint suggested `cp -r` — a command that does not exist in cmd.exe or PowerShell.
+
+**Coverage widened.** A new `cli/snapshot-guard.ts` centralizes the pre-command snapshot and now guards `add`, `reshape`, `prune`, `reorganize`, `remove`, `move`, and `fix`. The guard **fails closed**: if a snapshot cannot be created, the command aborts rather than rewriting the tree unprotected. `--no-snapshot` opts out for read-only filesystems and CI. `update` is deliberately excluded — it is on hench's hot path and a full-tree copy per task-status transition would be a significant regression.
+
+Regression tests assert the snapshot directory contains none of Windows' reserved characters, that encoded ids stay chronologically sortable, that restore accepts both an encoded id and a raw ISO timestamp (for snapshots written before this fix), and that restore replaces rather than overlays.

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,23 @@ CLAUDE.md               text eol=lf
 .agents/**/*.md         text eol=lf
 .claude/skills/**/*.md  text eol=lf
 .codex/config.toml      text eol=lf
+
+# repo-only eol pins (not injected by ndx init)
+# Everything below is specific to this repository's own layout, so it is NOT
+# part of GITATTRIBUTES_EOL_RULES (which `ndx init` writes into consumer
+# projects). The sync guard in tests/e2e/prd-line-endings.test.js compares the
+# injector list against the section ABOVE this marker only.
+#
+# A shebang line must end with LF. `#!/usr/bin/env node\r\n` breaks direct
+# execution on Unix ("bad interpreter: ...^M") and breaks vitest's transform of
+# any script a test imports, which fails collection with the locationless
+# `SyntaxError: Invalid or unexpected token`. Every hashbang-bearing tracked
+# file is already LF in the index, so these pins add no content change — they
+# only stop Windows checkouts (core.autocrlf=true) from rewriting them to CRLF.
+*.sh                        text eol=lf
+*.mjs                       text eol=lf
+*.py                        text eol=lf
+packages/*/bin/*.js         text eol=lf
+packages/*/src/cli/index.ts text eol=lf
+packages/core/cli.js        text eol=lf
+packages/core/export.js     text eol=lf

--- a/.profile-tests-tmp/large/prd_tree/epic-601-major-delivery-7/feature-679-core-capability.md
+++ b/.profile-tests-tmp/large/prd_tree/epic-601-major-delivery-7/feature-679-core-capability.md
@@ -1,0 +1,7 @@
+---
+id: "feature-679"
+level: "feature"
+title: "Feature 679: Core capability"
+status: "pending"
+priority: "medium"
+---

--- a/.profile-tests-tmp/large/prd_tree/epic-601-major-delivery-7/feature-680-core-capability.md
+++ b/.profile-tests-tmp/large/prd_tree/epic-601-major-delivery-7/feature-680-core-capability.md
@@ -1,0 +1,7 @@
+---
+id: "feature-680"
+level: "feature"
+title: "Feature 680: Core capability"
+status: "pending"
+priority: "medium"
+---

--- a/.rex/prd_tree/llm-integration-7b2bbe/codex-workflow-parity-close-out-8f00a8.md
+++ b/.rex/prd_tree/llm-integration-7b2bbe/codex-workflow-parity-close-out-8f00a8.md
@@ -2,7 +2,7 @@
 id: "8f00a8b7-57dc-4989-bb37-a32cc7db54fc"
 level: "feature"
 title: "Codex workflow parity — close-out (issue #122 remainder)"
-status: "pending"
+status: "completed"
 priority: "medium"
 tags:
   - "codex-parity"
@@ -10,6 +10,11 @@ tags:
   - "issue-284"
   - "assistant-assets"
 source: "GitHub issue #122 (+ sub-issue #284); verification audit 2026-07-16"
+startedAt: "2026-08-06T22:14:02.459Z"
+completedAt: "2026-08-06T22:14:02.459Z"
+endedAt: "2026-08-06T22:14:02.459Z"
+resolutionType: "code-change"
+resolutionDetail: "All 6 acceptance criteria shipped in commit 56a63ea6 (PR #309, merged to main); PRD status was never flipped. Verified 2026-08-06: body-drift test exists (tests/e2e/assistant-body-drift.test.js), Changeset Versioning section lives in project-guidance.md and appears in both CLAUDE.md + AGENTS.md, .claude/skills/ removed from .gitignore with 12 skills git-tracked, checkSkillTracking() gitignore hint in assistant-integration.js, docs sweep done with assertions in assistant-parity-smoke.test.js, changeset .changeset/codex-parity-closeout.md present. 234 tests pass across the feature surface."
 acceptanceCriteria: []
 description: "Final close-out of the Codex workflow-parity epic (#122). Four of five acceptance criteria already shipped; this feature completes the last one (tests fail on drift) plus the tracking-asymmetry sub-issue (#284) and a two-line docs sweep.\n\nKey discovery during scoping (2026-07-20): the committed root CLAUDE.md has already DRIFTED from the canonical source — it carries a '## Changeset Versioning' section that does NOT exist in packages/core/assistant-assets/project-guidance.md, so the generator (renderClaudeMd) does not emit it, and AGENTS.md silently lacks the rule. This is exactly the body-drift class the missing regression test must catch: a body-drift test written today FAILS on main. Fix = move that section into project-guidance.md (shared) so both CLAUDE.md and AGENTS.md carry it, then regenerate.\n\n#284 decision (made 2026-07-20): COMMIT BOTH. The shipped ndx.gitignore template already ignores neither vendor's skills, so downstream projects are already symmetric; the asymmetry is only in the n-dx repo's own .gitignore (line: .claude/skills/). Fix = drop that rule, commit the 9 generated Claude ndx-* skills (they already match renderSkill output on disk), and add a missing-skills / gitignore-tracking hint at init as a safety net.\n\nImplementation is TDD-first in an interactive Claude Code session (NOT autonomous ndx work) because (a) the drift nuance doesn't survive compression into a terse brief and (b) GH #303 hench rollback runs unscoped git checkout . + git clean -fd, which is unsafe on a dirty tree.</description>\n<parameter name=\"acceptanceCriteria\">[\"Body-drift regression test exists (tests/e2e) that regenerates from the canonical source and asserts committed CLAUDE.md == renderClaudeMd(), AGENTS.md == renderAgentsMd(), and every vendor skill file == renderSkill(name, vendor); it fails if any committed artifact diverges from the generator (line-ending-normalized).\", \"The '## Changeset Versioning' section is moved into packages/core/assistant-assets/project-guidance.md (shared), CLAUDE.md and AGENTS.md are regenerated, and the body-drift test passes green.\", \"#284: .claude/skills/ is removed from the n-dx repo .gitignore and the 9 generated Claude ndx-* skills are committed, matching the already-committed Codex skills; a test asserts the generated Claude skills are git-tracked.\", \"A missing-skills / gitignore-tracking hint is surfaced at ndx init when an enabled vendor's skill directory is gitignored (so generated skills won't be shared), with test coverage.\", \"Docs sweep: packages/web/README.md no longer describes MCP endpoints as Claude-only, and docs/guide/troubleshooting.md line ~106 no longer implies only Claude MCP servers are re-registered; assistant-parity-smoke asserts the exact strings are gone.\", \"pnpm build, typecheck, and test pass for affected packages; a patch changeset is added; PR opened fork->origin and #122 + #284 closed.\"]"
 ---

--- a/.rex/prd_tree/llm-integration-7b2bbe/index.md
+++ b/.rex/prd_tree/llm-integration-7b2bbe/index.md
@@ -46,5 +46,5 @@ description: "AI client infrastructure: vendor-neutral LLM foundation, token usa
 | [Token Usage Attribution per PRD Item](./token-usage-attribution-per-prd-item/index.md) | completed |
 | [Token usage tracking and analytics](./token-usage-tracking-and-analytics/index.md) | completed |
 | [Unified Server Architecture: HTTP MCP and ndx start](./unified-server-architecture-e96db7/index.md) | completed |
-| [Codex workflow parity — close-out (issue #122 remainder)](./codex-workflow-parity-close-out-8f00a8.md) | pending |
+| [Codex workflow parity — close-out (issue #122 remainder)](./codex-workflow-parity-close-out-8f00a8.md) | completed |
 | [`ndx add` ignores configured Google/Gemini vendor and falls back to Claude](./ndx-add-ignores-configured-46d8b9.md) | completed |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Alternatives: `pnpm add -g @n-dx/core` (equivalent), or `yarn global add @n-dx/c
 `npx -p @n-dx/core ndx <command>` — bare `npx @n-dx/core` does not work.
 See [Install Path Validation](docs/process/install-path-validation.md) for the tested-behavior rationale.
 
+**Upgrading:** always pass an explicit `@latest` tag — `npm i -g @n-dx/core@latest`
+or `pnpm add -g @n-dx/core@latest`. While the project is on 0.x, a bare upgrade
+re-resolves inside the caret range recorded at install time (`^0.3.1` means
+`>=0.3.1 <0.4.0`), so it cannot cross a minor boundary. Upgrade with the same
+package manager you installed with; see
+[Troubleshooting](docs/guide/troubleshooting.md) if `ndx --version` does not change.
+
 Then run:
 
 ```sh

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -2,6 +2,55 @@
 
 Common issues and how to fix them. If your issue isn't listed here, use the `/ndx-feedback` skill in your assistant (Claude Code or Codex) to report it — it'll file a GitHub issue with your environment details automatically.
 
+## `ERR_MODULE_NOT_FOUND` on every `ndx` command
+
+**Problem**: Any `ndx` command crashes immediately with a stack trace like:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+'.../node_modules/assistant-assets/index.js' imported from
+'.../node_modules/@n-dx/core/claude-integration.js'
+```
+
+**Cause**: You are on `@n-dx/core` 0.3.x, which shipped with an import path that
+escaped the published tarball. The referenced file was never included, so Node
+fails while linking the module graph — before any `ndx` code runs. Fixed in
+0.4.0.
+
+Reinstalling alone often does **not** help. pnpm records a caret range in its
+global manifest, and for 0.x versions `^0.3.1` means `>=0.3.1 <0.4.0` — so
+`pnpm add -g @n-dx/core` and `pnpm update -g` both re-resolve inside the broken
+0.3 line and can never reach the fix.
+
+**Fix**: reinstall with an explicit `@latest` tag, which pins past the recorded
+range:
+
+```sh
+# pnpm — remove first so the stale caret range is dropped from the manifest
+pnpm remove -g @n-dx/core
+pnpm add -g @n-dx/core@latest
+
+# npm
+npm i -g @n-dx/core@latest
+```
+
+Then confirm the version actually changed:
+
+```sh
+ndx --version    # expect 0.4.0 or newer
+```
+
+Two things to watch for:
+
+- **Run these from outside an n-dx checkout.** The repo's `.npmrc` sets
+  `minimum-release-age`, and pnpm reads a local `.npmrc` even for `-g`
+  operations — from inside the repo it will refuse recent releases.
+- **Don't switch package managers to upgrade.** Installing with npm when your
+  existing global install came from pnpm leaves *two* `ndx` shims on `PATH`.
+  Whichever resolves first wins, so `ndx --version` can keep reporting the old
+  version even though the upgrade succeeded. Upgrade with the same manager you
+  installed with, or remove the other install first.
+
 ## "Unknown command" when running rex/sourcevision/hench commands
 
 **Problem**: Running `rex plan` or `sourcevision init` fails with "unknown command."

--- a/packages/core/update-check.js
+++ b/packages/core/update-check.js
@@ -14,6 +14,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const REGISTRY_URL = "https://registry.npmjs.org/@n-dx/core/latest";
 
@@ -99,6 +100,55 @@ function isNewer(current, latest) {
   return lPat > cPat;
 }
 
+// ── Install-manager detection ─────────────────────────────────────────────────
+
+/**
+ * Infer which package manager installed the running copy of @n-dx/core by
+ * inspecting its own path on disk.
+ *
+ * Why this matters: telling a pnpm-global user to run `npm i -g` creates a
+ * SECOND global install under the npm prefix. Both ship an `ndx` shim, and
+ * whichever lands earlier on PATH wins — so the user can "successfully
+ * upgrade" and still be running the old copy, with no error to explain it.
+ *
+ * Signals (checked in order):
+ *  - pnpm always materializes packages inside a `.pnpm` virtual store, and its
+ *    global root lives under a `pnpm/` directory. Either segment is conclusive.
+ *  - yarn classic installs globals under a `yarn/` data directory.
+ *  - anything else (including npm's prefix and a local dev checkout) → npm.
+ *
+ * @param {string} [modulePath] Absolute path to a file inside the install.
+ *   Defaults to this module. Injectable for tests.
+ * @returns {"pnpm"|"yarn"|"npm"}
+ */
+export function detectInstallManager(modulePath = fileURLToPath(import.meta.url)) {
+  // Normalize Windows separators so one set of segment checks covers both
+  // platforms; lowercase because Windows paths are case-insensitive.
+  const path = modulePath.replace(/\\/g, "/").toLowerCase();
+  if (path.includes("/.pnpm/") || path.includes("/pnpm/")) return "pnpm";
+  if (path.includes("/yarn/")) return "yarn";
+  return "npm";
+}
+
+/**
+ * Build the upgrade command for a given package manager.
+ *
+ * The explicit `@latest` tag is load-bearing, not decorative. pnpm records a
+ * caret range in its global manifest (e.g. `"@n-dx/core": "^0.3.1"`), and for
+ * 0.x versions `^0.3.1` means `>=0.3.1 <0.4.0`. A bare `pnpm add -g @n-dx/core`
+ * or `pnpm update -g` re-resolves inside that range and can never cross a minor
+ * boundary, so the user stays stranded on the old line no matter how many times
+ * they "upgrade". `@latest` pins past it.
+ *
+ * @param {"pnpm"|"yarn"|"npm"} [manager]
+ * @returns {string}
+ */
+export function formatUpgradeCommand(manager = detectInstallManager()) {
+  if (manager === "pnpm") return "pnpm add -g @n-dx/core@latest";
+  if (manager === "yarn") return "yarn global add @n-dx/core@latest";
+  return "npm i -g @n-dx/core@latest";
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
@@ -138,18 +188,24 @@ export async function startUpdateCheck({ currentVersion } = {}) {
 /**
  * Format a one-line update notice for display after command output.
  *
- * @param {{ current: string, latest: string }} info
+ * The suggested command is matched to the package manager that actually
+ * installed this copy — see `detectInstallManager` for why a hardcoded
+ * `npm i -g` silently breaks pnpm and yarn users.
+ *
+ * @param {{ current: string, latest: string, manager?: "pnpm"|"yarn"|"npm" }} info
  * @returns {string}
  */
-export function formatUpdateNotice({ current, latest }) {
+export function formatUpdateNotice({ current, latest, manager }) {
   // Use plain ANSI without importing cli-brand so this module stays
   // self-contained and testable without side-effects.
   const dim = (t) => `\x1b[2m${t}\x1b[22m`;
   const bold = (t) => `\x1b[1m${t}\x1b[22m`;
   const cyan = (t) => `\x1b[36m${t}\x1b[39m`;
 
+  const command = formatUpgradeCommand(manager ?? detectInstallManager());
+
   return (
     `\n  ${dim("Update available:")} ${dim(current)} → ${cyan(bold(latest))}` +
-    `  ${dim("Run")} ${bold("npm i -g @n-dx/core")} ${dim("to update.")}`
+    `  ${dim("Run")} ${bold(command)} ${dim("to update.")}`
   );
 }

--- a/packages/core/win-spawn.js
+++ b/packages/core/win-spawn.js
@@ -54,12 +54,32 @@ export function quoteWindowsToken(token) {
 }
 
 /**
+ * A binary token that is a plain bare command name — no spaces, quotes, path
+ * separators, or cmd.exe metacharacters, so it needs no quoting.
+ *
+ * TWIN: exact copy of WINDOWS_BARE_BINARY_RE in packages/llm-client/src/exec.ts.
+ */
+const WINDOWS_BARE_BINARY_RE = /^[A-Za-z0-9_.+-]+$/;
+
+/**
  * Build a Windows cmd.exe verbatim command line from a binary path and args.
  * TWIN: exact copy of buildWindowsCliCommandLine in packages/llm-client/src/exec.ts.
  * Exported for the cross-package parity test.
+ *
+ * Args are always quoted; a bare command name is left UNQUOTED so cmd.exe still
+ * applies PATHEXT resolution. Quoting the command name makes cmd match an exact
+ * filename on PATH, which picks the extensionless POSIX script that pnpm/npm
+ * global installs place beside the `.CMD` shim and fails with
+ * `The system cannot find the path specified.` See the canonical copy in
+ * exec.ts for the full rationale.
+ *
+ * LIMITATION: an unquoted bare name that collides with a cmd.exe internal
+ * command (`echo`, `dir`, `set`, …) resolves to the builtin, not a file on PATH.
+ * No CLI spawned here collides; pass an absolute path if one ever does.
  */
 export function buildWindowsCliCommandLine(binary, args) {
-  return [binary, ...args].map(quoteWindowsToken).join(" ");
+  const head = WINDOWS_BARE_BINARY_RE.test(binary) ? binary : quoteWindowsToken(binary);
+  return [head, ...args.map(quoteWindowsToken)].join(" ");
 }
 
 /**

--- a/packages/llm-client/src/exec.ts
+++ b/packages/llm-client/src/exec.ts
@@ -884,13 +884,46 @@ export function quoteWindowsToken(token: string): string {
 }
 
 /**
+ * A binary token that is a plain bare command name — letters, digits, and the
+ * safe punctuation that appears in real CLI names (`.`, `-`, `_`, `+`). No
+ * spaces, quotes, path separators, or cmd.exe metacharacters, so it needs no
+ * quoting to survive tokenization.
+ *
+ * TWIN: mirrored in `packages/core/win-spawn.js`.
+ */
+const WINDOWS_BARE_BINARY_RE = /^[A-Za-z0-9_.+-]+$/;
+
+/**
  * Build a Windows cmd.exe verbatim command line from a binary path and args.
  *
  * Pure function — safe to call on any platform; its tests run on every CI.
- * Each token is quoted unconditionally by {@link quoteWindowsToken}.
+ * Every ARGUMENT is quoted unconditionally by {@link quoteWindowsToken}.
+ *
+ * The BINARY is quoted only when it needs it (spaces, quotes, path separators,
+ * metacharacters). A bare command name is emitted UNQUOTED, because quoting the
+ * command name suppresses cmd.exe's PATHEXT resolution: cmd then looks for an
+ * exact filename match on PATH instead of trying `.CMD`/`.EXE`/… in turn. When
+ * a PATH directory holds an extensionless file beside its shim — exactly what
+ * pnpm/npm global installs produce (`pnpm` + `pnpm.CMD`, `claude` + `claude.CMD`)
+ * — the quoted form finds the extensionless POSIX script, fails CreateProcess,
+ * and exits 1 with `The system cannot find the path specified.`
+ *
+ *   `cmd /d /s /c ""pnpm" "--version""`  →  exit 1, path-not-found
+ *   `cmd /d /s /c "pnpm "--version""`    →  exit 0, resolves pnpm.CMD
+ *
+ * Quoted paths keep their quotes and still resolve (verified for both
+ * `C:\...\pnpm` and `C:\...\pnpm.CMD`), so spaced-path handling (#68) is
+ * unaffected.
+ *
+ * LIMITATION: an unquoted bare name that collides with a cmd.exe INTERNAL
+ * command (`echo`, `dir`, `set`, `start`, …) resolves to the builtin rather than
+ * to a file on PATH. No vendor CLI this helper spawns (`claude`, `codex`,
+ * `pnpm`, `node`, `git`, `gemini`) collides; pass an absolute path if one ever
+ * does.
  */
 export function buildWindowsCliCommandLine(binary: string, args: string[]): string {
-  return [binary, ...args].map(quoteWindowsToken).join(" ");
+  const head = WINDOWS_BARE_BINARY_RE.test(binary) ? binary : quoteWindowsToken(binary);
+  return [head, ...args.map(quoteWindowsToken)].join(" ");
 }
 
 /**

--- a/packages/llm-client/tests/helpers/fake-cli.ts
+++ b/packages/llm-client/tests/helpers/fake-cli.ts
@@ -1,0 +1,69 @@
+/**
+ * Cross-platform fake CLI binaries for provider spawn tests.
+ *
+ * Provider tests need a stand-in for `claude` / `codex` that emits fixed output
+ * and exits with a chosen code. Writing that as a shebang script works only on
+ * POSIX: Windows has no shebang support, so `cmd.exe` cannot execute a
+ * `#!/bin/sh` or `#!/usr/bin/env node` file. `spawnCli` routes through cmd.exe
+ * on win32, which then reports the fake as "exists but could not be run" — the
+ * provider classifies that as a not-found error and every assertion about the
+ * fake's real output fails. This helper keeps the behavior in a Node module and
+ * gives each platform a shim it can actually launch.
+ */
+
+import { chmodSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface FakeCliOptions {
+  /** Base name of the binary; the test points `cli_path` at the returned path. */
+  name: string;
+  /** Written to stdout before exiting. */
+  stdout?: string;
+  /** Written to stderr before exiting. */
+  stderr?: string;
+  /** Process exit code. Defaults to 0. */
+  exitCode?: number;
+  /**
+   * Read stdin to EOF before emitting output. Providers deliver the prompt on
+   * stdin, so a fake that exits first can make the parent's write fail with
+   * EPIPE. Defaults to false — enable it for the fakes that need to drain.
+   */
+  drainStdin?: boolean;
+}
+
+/**
+ * Write a fake CLI into `dir` and return the path to launch.
+ *
+ * @returns Absolute path to the shim (`<name>.cmd` on win32, `<name>` elsewhere).
+ */
+export function writeFakeCli(dir: string, options: FakeCliOptions): string {
+  const { name, stdout = "", stderr = "", exitCode = 0, drainStdin = false } = options;
+
+  // Behavior lives in a .mjs file so it is ESM on every platform — an
+  // extensionless `#!/usr/bin/env node` script loads as CommonJS, where the
+  // top-level await used to drain stdin would be a syntax error.
+  const impl = join(dir, `${name}-impl.mjs`);
+  writeFileSync(
+    impl,
+    [
+      ...(drainStdin ? ["for await (const _chunk of process.stdin) { /* drain */ }"] : []),
+      ...(stdout ? [`process.stdout.write(${JSON.stringify(stdout)});`] : []),
+      ...(stderr ? [`process.stderr.write(${JSON.stringify(stderr)});`] : []),
+      `process.exit(${exitCode});`,
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  if (process.platform === "win32") {
+    // `exit /b %ERRORLEVEL%` so node's exit code is what the caller observes.
+    const shim = join(dir, `${name}.cmd`);
+    writeFileSync(shim, `@echo off\r\nnode "${impl}" %*\r\nexit /b %ERRORLEVEL%\r\n`, "utf-8");
+    return shim;
+  }
+
+  const shim = join(dir, name);
+  writeFileSync(shim, `#!/bin/sh\nexec node "${impl}" "$@"\n`, "utf-8");
+  chmodSync(shim, 0o755);
+  return shim;
+}

--- a/packages/llm-client/tests/unit/cli-provider.test.ts
+++ b/packages/llm-client/tests/unit/cli-provider.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { writeFakeCli } from "../helpers/fake-cli.js";
 import { createCliClient } from "../../src/cli-provider.js";
 import { ClaudeClientError } from "../../src/types.js";
 import type { LLMProvider } from "../../src/provider-interface.js";
@@ -72,12 +73,21 @@ describe("createCliClient", () => {
 });
 
 describe("createCliClient — stdout error envelope", () => {
-  function writeFakeCli(body: string): { dir: string; path: string } {
+  /**
+   * Fake `claude` in a fresh temp dir. Drains stdin because the provider writes
+   * the prompt there, then emits `stdout` and exits `exitCode`. The fake is a
+   * Node script behind a platform shim — a shebang script is unrunnable on
+   * Windows (see tests/helpers/fake-cli.ts).
+   */
+  function makeFakeCli(
+    stdout: string,
+    exitCode: number,
+  ): { dir: string; path: string } {
     const dir = mkdtempSync(join(tmpdir(), "claude-fake-"));
-    const path = join(dir, "claude");
-    writeFileSync(path, body, { mode: 0o755 });
-    chmodSync(path, 0o755);
-    return { dir, path };
+    return {
+      dir,
+      path: writeFakeCli(dir, { name: "claude", stdout, exitCode, drainStdin: true }),
+    };
   }
 
   it("surfaces JSON stdout error envelope when stderr is empty and exit is non-zero", async () => {
@@ -87,9 +97,7 @@ describe("createCliClient — stdout error envelope", () => {
       api_error_status: 429,
       result: "You've hit your limit · resets Apr 23 at 12pm (America/Los_Angeles)",
     });
-    const { dir, path } = writeFakeCli(
-      `#!/bin/sh\ncat > /dev/null\nprintf '%s' '${envelope.replace(/'/g, "'\\''")}'\nexit 1\n`,
-    );
+    const { dir, path } = makeFakeCli(envelope, 1);
 
     try {
       const client = createCliClient({
@@ -110,7 +118,7 @@ describe("createCliClient — stdout error envelope", () => {
   });
 
   it("falls back to the exit-code string when stdout has no error envelope", async () => {
-    const { dir, path } = writeFakeCli("#!/bin/sh\ncat > /dev/null\nexit 1\n");
+    const { dir, path } = makeFakeCli("", 1);
 
     try {
       const client = createCliClient({
@@ -144,9 +152,7 @@ describe("createCliClient — stdout error envelope", () => {
         usage: { input_tokens: 12, output_tokens: 7 },
       },
     ]);
-    const { dir, path } = writeFakeCli(
-      `#!/bin/sh\ncat > /dev/null\nprintf '%s' '${arrayBody.replace(/'/g, "'\\''")}'\nexit 0\n`,
-    );
+    const { dir, path } = makeFakeCli(arrayBody, 0);
 
     try {
       const client = createCliClient({
@@ -167,9 +173,7 @@ describe("createCliClient — stdout error envelope", () => {
       input_tokens: 5,
       output_tokens: 9,
     });
-    const { dir, path } = writeFakeCli(
-      `#!/bin/sh\ncat > /dev/null\nprintf '%s' '${envelope.replace(/'/g, "'\\''")}'\nexit 0\n`,
-    );
+    const { dir, path } = makeFakeCli(envelope, 0);
 
     try {
       const client = createCliClient({

--- a/packages/llm-client/tests/unit/codex-cli-provider.test.ts
+++ b/packages/llm-client/tests/unit/codex-cli-provider.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { writeFile, chmod, mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { writeFakeCli } from "../helpers/fake-cli.js";
 import {
   mapSandboxToCodexFlag,
   mapApprovalToCodexFlag,
@@ -111,24 +112,18 @@ describe("Codex policy flag compilation", () => {
 // ── Rate limit retry behavior ────────────────────────────────────────────────
 
 /**
- * Create a temporary executable Node.js script that writes `stderr` to stderr
- * and exits with `exitCode`. The binary ignores all arguments so it can act as
- * a stand-in for any `codex exec ...` invocation.
+ * Create a temporary fake `codex` that writes `stderr` to stderr and exits with
+ * `exitCode`. The binary ignores all arguments so it can act as a stand-in for
+ * any `codex exec ...` invocation.
+ *
+ * Delegates to the shared helper so the fake is launchable on Windows too — a
+ * bare `#!/usr/bin/env node` script is not (see tests/helpers/fake-cli.ts).
  */
 async function makeMockBinary(
   tmpDir: string,
   { stderr, exitCode }: { stderr: string; exitCode: number },
 ): Promise<string> {
-  const scriptPath = join(tmpDir, "mock-codex");
-  const content = [
-    "#!/usr/bin/env node",
-    `process.stderr.write(${JSON.stringify(stderr)});`,
-    `process.exit(${exitCode});`,
-    "",
-  ].join("\n");
-  await writeFile(scriptPath, content, "utf-8");
-  await chmod(scriptPath, 0o755);
-  return scriptPath;
+  return writeFakeCli(tmpDir, { name: "mock-codex", stderr, exitCode });
 }
 
 describe("createCodexCliClient — rate limit retry", () => {

--- a/packages/llm-client/tests/unit/exec.test.ts
+++ b/packages/llm-client/tests/unit/exec.test.ts
@@ -818,10 +818,20 @@ describe("quoteWindowsToken", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildWindowsCliCommandLine", () => {
-  it("quotes every token in a simple command line", () => {
+  it("quotes every arg and leaves a bare binary name unquoted", () => {
     expect(buildWindowsCliCommandLine("claude", ["--print", "hello"])).toBe(
-      '"claude" "--print" "hello"',
+      'claude "--print" "hello"',
     );
+  });
+
+  // Quoting the command name suppresses cmd.exe PATHEXT resolution, so cmd
+  // matches an exact filename on PATH and finds the extensionless POSIX script
+  // that pnpm/npm global installs place beside the .CMD shim — CreateProcess
+  // then fails with "The system cannot find the path specified."
+  it("leaves bare names unquoted so cmd.exe PATHEXT resolution still applies", () => {
+    for (const bare of ["pnpm", "claude", "codex", "node", "some-cli", "cli_v2.1"]) {
+      expect(buildWindowsCliCommandLine(bare, ["--version"])).toBe(`${bare} "--version"`);
+    }
   });
 
   it("quotes a binary path that contains spaces", () => {
@@ -830,19 +840,28 @@ describe("buildWindowsCliCommandLine", () => {
     ).toBe('"C:\\Program Files\\claude\\claude.cmd" "--print"');
   });
 
+  it("quotes a binary that contains a path separator or metacharacter", () => {
+    expect(buildWindowsCliCommandLine("C:\\tools\\claude.cmd", [])).toBe(
+      '"C:\\tools\\claude.cmd"',
+    );
+    expect(buildWindowsCliCommandLine("./local-cli", [])).toBe('"./local-cli"');
+    expect(buildWindowsCliCommandLine("weird&name", [])).toBe('"weird&name"');
+    expect(buildWindowsCliCommandLine("", ["--print"])).toBe('"" "--print"');
+  });
+
   it("quotes an arg that contains spaces", () => {
     expect(buildWindowsCliCommandLine("claude", ["--print", "hello world"])).toBe(
-      '"claude" "--print" "hello world"',
+      'claude "--print" "hello world"',
     );
   });
 
   it("handles empty args list", () => {
-    expect(buildWindowsCliCommandLine("claude", [])).toBe('"claude"');
+    expect(buildWindowsCliCommandLine("claude", [])).toBe("claude");
   });
 
   it("keeps an empty positional arg as a quoted empty string", () => {
     expect(buildWindowsCliCommandLine("claude", ["", "--print"])).toBe(
-      '"claude" "" "--print"',
+      'claude "" "--print"',
     );
   });
 
@@ -882,7 +901,7 @@ describe("spawnCli", () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "cmd.exe",
-      ["/d", "/s", "/c", '""claude.cmd" "--print" "hi""'],
+      ["/d", "/s", "/c", '"claude.cmd "--print" "hi""'],
       expect.objectContaining({ windowsVerbatimArguments: true }),
     );
     const spawnOpts = mockSpawn.mock.calls[0][2] as Record<string, unknown>;

--- a/packages/rex/src/cli/commands/add.ts
+++ b/packages/rex/src/cli/commands/add.ts
@@ -11,7 +11,7 @@ import { LEVEL_HIERARCHY, CHILD_LEVEL, isItemLevel } from "../../schema/index.js
 import { findItem } from "../../core/tree.js";
 import { validateDAG } from "../../core/dag.js";
 import { migrateToFolderPerTask } from "../../core/folder-per-task-migration.js";
-import { snapshotPRDTree, pruneBackups } from "../../core/backup-snapshots.js";
+import { ensureSnapshot, formatRecoveryHint } from "../snapshot-guard.js";
 import { REX_DIR } from "./constants.js";
 import { syncFolderTree } from "./folder-tree-sync.js";
 import { cascadeParentReset } from "../../core/parent-reset.js";
@@ -45,14 +45,9 @@ export async function cmdAdd(
   // Emit migration notification to CLI and execution log
   await emitMigrationNotification(migrationResult, flags, (entry) => store.appendLog(entry));
 
-  // Snapshot PRD tree before structural migration (backup for recovery on failure)
-  let backupSnapshot = null;
-  try {
-    backupSnapshot = await snapshotPRDTree(rexDir);
-  } catch (err) {
-    // Best-effort: don't fail the command if backup creation fails
-    warn(`Warning: Failed to create backup snapshot: ${String(err)}`);
-  }
+  // Snapshot the PRD tree before we touch it, so `rex restore` can return the
+  // user to this exact point. Fails closed — see cli/snapshot-guard.ts.
+  const backupSnapshot = await ensureSnapshot(rexDir, "add", flags);
 
   // Run folder-per-task structural migration pass (pre-write check)
   const treeRoot = join(rexDir, "prd_tree");
@@ -63,13 +58,10 @@ export async function cmdAdd(
   try {
     folderPerTaskMigrationResult = await migrateToFolderPerTask(treeRoot);
   } catch (err) {
-    // Surface backup path in error message for recovery
-    const backupMsg = backupSnapshot
-      ? `\n\nBackup saved to: ${backupSnapshot.backupPath}\nRestore with: cp -r ${backupSnapshot.backupPath} ${treeRoot}`
-      : "";
+    // Surface the rollback command for recovery
     throw new CLIError(
-      `Migration failed: ${String(err)}${backupMsg}`,
-      "Check the backup path above to restore the PRD tree.",
+      `Migration failed: ${String(err)}${formatRecoveryHint(backupSnapshot, dir)}`,
+      "Roll the PRD tree back with 'rex restore' as shown above.",
     );
   }
 
@@ -80,15 +72,6 @@ export async function cmdAdd(
   }
   if (folderPerTaskMigrationResult.migratedCount > 0 && flags.format !== "json") {
     info(`Migrated ${folderPerTaskMigrationResult.migratedCount} item${folderPerTaskMigrationResult.migratedCount === 1 ? "" : "s"} to folder-per-task form.`);
-  }
-
-  // Prune old backups if migrations were applied
-  if (folderPerTaskMigrationResult.migratedCount > 0) {
-    try {
-      await pruneBackups(rexDir, 10);
-    } catch {
-      // Best-effort: don't fail the command if pruning fails
-    }
   }
 
   // Ensure the current branch's PRD file exists and is the write target.

--- a/packages/rex/src/cli/commands/fix.ts
+++ b/packages/rex/src/cli/commands/fix.ts
@@ -4,6 +4,7 @@ import { detectIssues, applyFixes } from "../../fix/index.js";
 import type { FixAction, FixKind } from "../../fix/index.js";
 import { REX_DIR } from "./constants.js";
 import { info, result } from "../output.js";
+import { ensureSnapshot } from "../snapshot-guard.js";
 
 /**
  * Auto-fix common PRD validation issues.
@@ -18,6 +19,9 @@ export async function cmdFix(
 ): Promise<void> {
   const rexDir = join(dir, REX_DIR);
   const store = await resolveStore(rexDir);
+
+  // Snapshot the tree before any mutation so `rex restore` can undo this fix.
+  await ensureSnapshot(rexDir, "fix", flags);
   const doc = await store.loadDocument();
 
   const dryRun = flags["dry-run"] === "true";

--- a/packages/rex/src/cli/commands/move.ts
+++ b/packages/rex/src/cli/commands/move.ts
@@ -5,6 +5,7 @@ import { REX_DIR } from "./constants.js";
 import { syncFolderTree } from "./folder-tree-sync.js";
 import { CLIError } from "../errors.js";
 import { info, result } from "../output.js";
+import { ensureSnapshot } from "../snapshot-guard.js";
 
 export async function cmdMove(
   dir: string,
@@ -16,6 +17,9 @@ export async function cmdMove(
 
   const rexDir = join(dir, REX_DIR);
   const store = await resolveStore(rexDir);
+
+  // Snapshot the tree before any mutation so `rex restore` can undo this move.
+  await ensureSnapshot(rexDir, "move", flags);
   const doc = await store.loadDocument();
 
   const newParentId = flags.parent || undefined;

--- a/packages/rex/src/cli/commands/prune.ts
+++ b/packages/rex/src/cli/commands/prune.ts
@@ -19,6 +19,7 @@ import { classifyLLMError } from "../llm-error-classifier.js";
 import { printVendorModelHeader } from "@n-dx/llm-client";
 import type { PRDItem } from "../../schema/index.js";
 import { getLevelEmoji, formatLevelSummary as formatLevels } from "../../schema/index.js";
+import { ensureSnapshot } from "../snapshot-guard.js";
 
 // ── Parsed flag helpers ──────────────────────────────────────────────
 
@@ -112,6 +113,9 @@ export async function cmdPrune(
 
   const rexDir = join(dir, REX_DIR);
   const store = await resolveStore(rexDir);
+
+  // Snapshot the tree before any mutation so `rex restore` can undo this prune.
+  await ensureSnapshot(rexDir, "prune", flags);
   const doc = await store.loadDocument();
 
   const dryRun = flags["dry-run"] === "true";

--- a/packages/rex/src/cli/commands/remove.ts
+++ b/packages/rex/src/cli/commands/remove.ts
@@ -15,6 +15,7 @@ import { CLIError } from "../errors.js";
 import { info, warn, result } from "../output.js";
 import type { ItemStatus } from "../../schema/index.js";
 import { isRootLevel, getLevelLabel } from "../../schema/index.js";
+import { ensureSnapshot } from "../snapshot-guard.js";
 
 /**
  * Supported levels for the remove command.
@@ -63,6 +64,9 @@ export async function cmdRemove(
 
   const rexDir = join(dir, REX_DIR);
   const store = await resolveStore(rexDir);
+
+  // Snapshot the tree before any mutation so `rex restore` can undo this remove.
+  await ensureSnapshot(rexDir, "remove", flags);
   const doc = await store.loadDocument();
 
   // Resolve the item and validate (accepts UUID or exact title)

--- a/packages/rex/src/cli/commands/reorganize.ts
+++ b/packages/rex/src/cli/commands/reorganize.ts
@@ -22,6 +22,7 @@ import { loadClaudeConfig, loadLLMConfig } from "../../store/project-config.js";
 import { printVendorModelHeader } from "@n-dx/llm-client";
 import { preflightBudgetCheck, formatBudgetWarnings } from "./token-format.js";
 import { classifyLLMError } from "../llm-error-classifier.js";
+import { ensureSnapshot } from "../snapshot-guard.js";
 
 // ── LLM analysis ──────────────────────────────────────────────────────
 
@@ -279,6 +280,9 @@ export async function cmdReorganize(
 ): Promise<void> {
   const rexDir = join(dir, REX_DIR);
   const store = await resolveStore(rexDir);
+
+  // Snapshot the tree before any mutation so `rex restore` can undo this reorganize.
+  await ensureSnapshot(rexDir, "reorganize", flags);
   const doc = await store.loadDocument();
 
   if (doc.items.length === 0) {

--- a/packages/rex/src/cli/commands/reshape.ts
+++ b/packages/rex/src/cli/commands/reshape.ts
@@ -10,7 +10,7 @@ import { reasonForReshape, formatReshapeProposal, reasonForBodyMerge } from "../
 import { setLLMConfig, setClaudeConfig, resolveConfiguredModel } from "../../analyze/reason.js";
 import { loadLLMConfig, loadClaudeConfig } from "../../store/project-config.js";
 import { migrateToFolderPerTask } from "../../core/folder-per-task-migration.js";
-import { snapshotPRDTree, pruneBackups } from "../../core/backup-snapshots.js";
+import { ensureSnapshot, formatRecoveryHint } from "../snapshot-guard.js";
 import { captureGitCommitHash } from "../../core/git-utils.js";
 import { printVendorModelHeader } from "@n-dx/llm-client";
 import { REX_DIR } from "./constants.js";
@@ -59,13 +59,7 @@ async function _cmdReshapeCore(
 
   // Snapshot PRD tree before structural migrations (backup for recovery on failure)
   const treeRoot = join(rexDir, "prd_tree");
-  let backupSnapshot = null;
-  try {
-    backupSnapshot = await snapshotPRDTree(rexDir);
-  } catch (err) {
-    // Best-effort: don't fail the command if backup creation fails
-    warn(`Warning: Failed to create backup snapshot: ${String(err)}`);
-  }
+  const backupSnapshot = await ensureSnapshot(rexDir, "reshape", flags);
 
   // Run folder-per-task structural migration pass
   info("Migrating non-conforming task structures to folder-per-task form...");
@@ -73,13 +67,10 @@ async function _cmdReshapeCore(
   try {
     migrationResult = await migrateToFolderPerTask(treeRoot);
   } catch (err) {
-    // Surface backup path in error message for recovery
-    const backupMsg = backupSnapshot
-      ? `\n\nBackup saved to: ${backupSnapshot.backupPath}\nRestore with: cp -r ${backupSnapshot.backupPath} ${treeRoot}`
-      : "";
+    // Surface the rollback command for recovery
     throw new CLIError(
-      `Migration failed: ${String(err)}${backupMsg}`,
-      "Check the backup path above to restore the PRD tree.",
+      `Migration failed: ${String(err)}${formatRecoveryHint(backupSnapshot, dir)}`,
+      "Roll the PRD tree back with 'rex restore' as shown above.",
     );
   }
 
@@ -100,15 +91,6 @@ async function _cmdReshapeCore(
   // when no proposals end up being applied.
   const canonicalDoc = await store.loadDocument();
   await store.saveDocument(canonicalDoc);
-
-  // Prune old backups if migrations were applied
-  if (migrationResult.migratedCount > 0) {
-    try {
-      await pruneBackups(rexDir, 10);
-    } catch {
-      // Best-effort: don't fail the command if pruning fails
-    }
-  }
 
   const docAfterCompaction = canonicalDoc;
 

--- a/packages/rex/src/cli/commands/restore.ts
+++ b/packages/rex/src/cli/commands/restore.ts
@@ -1,0 +1,136 @@
+/**
+ * `rex restore` — roll the PRD tree back to a snapshot taken before a
+ * mutating command ran.
+ *
+ * Snapshots are created automatically by commands that rewrite the tree (see
+ * `core/backup-snapshots.ts`). This command is the user-facing half: without
+ * it, the snapshots existed on disk but there was no supported way to use
+ * them, so recovery meant hand-copying directories.
+ *
+ * @module cli/commands/restore
+ */
+
+import { join } from "node:path";
+import { readdir, stat } from "node:fs/promises";
+import { CLIError, requireRexDir } from "../errors.js";
+import { info, result, warn } from "../output.js";
+import { REX_DIR } from "./constants.js";
+import { getAvailableBackups, restoreFromBackup } from "../../core/backup-snapshots.js";
+
+/** Render a snapshot id back into a readable timestamp. */
+function formatSnapshotId(id: string): string {
+  // Ids are ISO-8601 with colons replaced by dashes. Put them back for display
+  // only — the on-disk name must stay colon-free for Windows.
+  const restored = id.replace(/T(\d{2})-(\d{2})-(\d{2})/, "T$1:$2:$3");
+  return restored;
+}
+
+/** Count files in a snapshot so the user can sanity-check size before restoring. */
+async function countFiles(dir: string): Promise<number> {
+  let total = 0;
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) total += await countFiles(join(dir, entry.name));
+    else total++;
+  }
+  return total;
+}
+
+async function confirmPrompt(question: string): Promise<boolean> {
+  const readline = await import("node:readline");
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => rl.question(question, resolve));
+  rl.close();
+  const normalized = answer.trim().toLowerCase();
+  return normalized === "y" || normalized === "yes";
+}
+
+export async function cmdRestore(
+  dir: string,
+  flags: Record<string, string>,
+): Promise<void> {
+  requireRexDir(dir);
+  const rexDir = join(dir, REX_DIR);
+  const backupsDir = join(rexDir, ".backups");
+  const isJson = flags.format === "json";
+
+  const snapshots = await getAvailableBackups(rexDir);
+
+  if (snapshots.length === 0) {
+    if (isJson) {
+      result(JSON.stringify({ snapshots: [], restored: null }, null, 2));
+      return;
+    }
+    warn("No PRD snapshots found.");
+    info(
+      "Snapshots are written to .rex/.backups/ before commands that rewrite the tree.\n" +
+        "If you are on a version older than the Windows snapshot fix, no snapshots were\n" +
+        "ever created on Windows — recover from git instead (`git restore -- .rex`).",
+    );
+    return;
+  }
+
+  // No target given: list what is available and stop. Listing must never mutate.
+  const requested = flags.id ?? flags.snapshot ?? null;
+  if (requested === null && flags.latest !== "true") {
+    if (isJson) {
+      result(JSON.stringify({ snapshots }, null, 2));
+      return;
+    }
+    info(`Available PRD snapshots (newest first):\n`);
+    for (const [index, id] of snapshots.entries()) {
+      const files = await countFiles(join(backupsDir, `prd_tree_${id}`));
+      const marker = index === 0 ? " (latest)" : "";
+      result(`  ${formatSnapshotId(id)}  ${files} files${marker}`);
+    }
+    info(
+      `\nRestore with:\n` +
+        `  rex restore --latest ${dir}\n` +
+        `  rex restore --id=${snapshots[0]} ${dir}`,
+    );
+    return;
+  }
+
+  const targetId = flags.latest === "true" ? snapshots[0] : requested!;
+  const targetPath = join(backupsDir, `prd_tree_${targetId}`);
+
+  const exists = await stat(targetPath)
+    .then((s) => s.isDirectory())
+    .catch(() => false);
+  if (!exists) {
+    throw new CLIError(
+      `Snapshot not found: ${targetId}`,
+      `Run 'rex restore ${dir}' to list available snapshots.`,
+    );
+  }
+
+  const fileCount = await countFiles(targetPath);
+
+  // Restoring deletes the live tree. Confirm unless explicitly waived.
+  const skipConfirm = flags.yes === "true" || isJson || !process.stdin.isTTY;
+  if (!skipConfirm) {
+    warn(
+      `This replaces .rex/prd_tree/ with snapshot ${formatSnapshotId(targetId)} ` +
+        `(${fileCount} files).\nAny PRD change made after that snapshot will be lost.`,
+    );
+    const confirmed = await confirmPrompt("Proceed with restore? (y/n) ");
+    if (!confirmed) {
+      info("Restore cancelled — nothing changed.");
+      return;
+    }
+  }
+
+  await restoreFromBackup(rexDir, targetId);
+
+  if (isJson) {
+    result(JSON.stringify({ restored: targetId, files: fileCount }, null, 2));
+    return;
+  }
+  result(`Restored PRD tree from snapshot ${formatSnapshotId(targetId)} (${fileCount} files).`);
+  info(`The snapshot remains in .rex/.backups/ — restoring does not consume it.`);
+}

--- a/packages/rex/src/cli/index.ts
+++ b/packages/rex/src/cli/index.ts
@@ -390,6 +390,11 @@ async function dispatchCommand(
       await cmdPrune(resolveDir(positional), flags);
       break;
     }
+    case "restore": {
+      const { cmdRestore } = await import("./commands/restore.js");
+      await cmdRestore(resolveDir(positional), flags);
+      break;
+    }
     case "validate": {
       const { cmdValidate } = await import("./commands/validate.js");
       await cmdValidate(resolveDir(positional), flags);
@@ -500,7 +505,7 @@ async function dispatchCommand(
 
       const REX_COMMANDS = [
         "init", "status", "tree", "next", "add", "update", "move", "remove", "reshape",
-        "prune", "validate", "fix", "sync", "usage", "report", "verify",
+        "prune", "restore", "validate", "fix", "sync", "usage", "report", "verify",
         "recommend", "analyze", "import", "adapter", "reorganize", "health", "mcp",
         "migrate-to-md", "migrate-to-folder-tree", "migrate-folder-tree-filenames", "parse-md",
         "backfill-commit-attribution",

--- a/packages/rex/src/cli/snapshot-guard.ts
+++ b/packages/rex/src/cli/snapshot-guard.ts
@@ -1,0 +1,95 @@
+/**
+ * Pre-command PRD tree snapshot guard.
+ *
+ * Every command that rewrites `.rex/prd_tree/` calls `ensureSnapshot` first, so
+ * a user can always return to the state the tree was in before the command ran
+ * (`rex restore`).
+ *
+ * Why this is a guard and not a best-effort warning: the previous behaviour
+ * caught snapshot failures and downgraded them to a one-line warning, then
+ * carried on and rewrote the tree anyway. Because the snapshot directory name
+ * embedded a raw ISO-8601 timestamp — and `:` is illegal in Windows filenames —
+ * that warning fired on *every* Windows invocation. The net effect was that
+ * Windows users ran destructive tree rewrites with no rollback at all, and the
+ * only signal was a line of text above the normal output. A safety net that
+ * silently isn't there is worse than no safety net, because it is trusted.
+ *
+ * @module cli/snapshot-guard
+ */
+
+import { warn } from "./output.js";
+import { CLIError } from "./errors.js";
+import {
+  snapshotPRDTree,
+  pruneBackups,
+  type BackupSnapshot,
+} from "../core/backup-snapshots.js";
+
+/** Number of snapshots to retain per project. */
+const RETENTION_CAP = 10;
+
+/**
+ * Snapshot the PRD tree before a mutating command.
+ *
+ * Returns the snapshot, or null when there was nothing to snapshot (no tree
+ * yet, or an empty tree — in both cases there is no data to lose).
+ *
+ * @param rexDir   The `.rex/` directory
+ * @param command  Command name, used in error text (e.g. "add", "prune")
+ * @param flags    Raw CLI flags. `--no-snapshot=true` opts out.
+ * @throws CLIError if the snapshot cannot be created and the caller did not
+ *   explicitly opt out. Failing closed is deliberate: the alternative is
+ *   rewriting the tree with no way back.
+ */
+export async function ensureSnapshot(
+  rexDir: string,
+  command: string,
+  flags: Record<string, string> = {},
+): Promise<BackupSnapshot | null> {
+  if (flags["no-snapshot"] === "true") {
+    warn(`Skipping PRD snapshot (--no-snapshot). 'rex restore' cannot undo this ${command}.`);
+    return null;
+  }
+
+  let snapshot: BackupSnapshot | null;
+  try {
+    snapshot = await snapshotPRDTree(rexDir);
+  } catch (err) {
+    throw new CLIError(
+      `Could not snapshot the PRD tree before '${command}': ${String(err)}\n\n` +
+        `Refusing to continue — without a snapshot there is no way to undo this command.`,
+      `Fix the cause above, or re-run with --no-snapshot to proceed without a rollback point.`,
+    );
+  }
+
+  // Retention is best-effort: a full backups directory must never block the
+  // command that just successfully protected itself.
+  if (snapshot !== null) {
+    try {
+      await pruneBackups(rexDir, RETENTION_CAP);
+    } catch {
+      // Ignore — stale snapshots are harmless.
+    }
+  }
+
+  return snapshot;
+}
+
+/**
+ * Format the recovery hint shown when a mutating command fails partway.
+ *
+ * Uses `rex restore` rather than a raw `cp -r`: the old hint suggested a Unix
+ * command that does not exist in cmd.exe/PowerShell, and a plain recursive copy
+ * overlays rather than replaces — leaving a tree that is the union of both
+ * states instead of the snapshot's point in time.
+ */
+export function formatRecoveryHint(
+  snapshot: BackupSnapshot | null,
+  dir: string,
+): string {
+  if (snapshot === null) return "";
+  return (
+    `\n\nThe PRD tree was snapshotted before this command.` +
+    `\nRoll back with: rex restore --id=${snapshot.id} ${dir}`
+  );
+}

--- a/packages/rex/src/core/backup-snapshots.ts
+++ b/packages/rex/src/core/backup-snapshots.ts
@@ -13,7 +13,7 @@
  * @module core/backup-snapshots
  */
 
-import { readdir, stat, mkdir, cp, rm } from "node:fs/promises";
+import { readdir, stat, mkdir, cp, rm, rename } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
@@ -22,8 +22,31 @@ import { join } from "node:path";
 export interface BackupSnapshot {
   /** ISO-8601 timestamp of the backup. */
   timestamp: string;
+  /**
+   * Filesystem-safe snapshot id — the suffix of the `prd_tree_<id>` directory
+   * name, and the value `getAvailableBackups` returns. Pass this (or the raw
+   * ISO timestamp) to `restoreFromBackup`.
+   */
+  id: string;
   /** Full path to the backed-up prd_tree. */
   backupPath: string;
+}
+
+/**
+ * Encode an ISO-8601 timestamp into a directory-name-safe id.
+ *
+ * Windows forbids `: \ / * ? " < > |` in filenames — `:` is reserved for drive
+ * letters and NTFS alternate data streams. ISO-8601 puts colons in the time
+ * component (`2026-08-05T17:27:18.959Z`), so every snapshot mkdir/cp failed
+ * with EINVAL on Windows. Because the failure was caught and downgraded to a
+ * warning by callers, Windows users silently had NO backup coverage at all.
+ *
+ * Colons become `-`. The substitution is positional and length-preserving, so
+ * lexicographic ordering still equals chronological ordering — which
+ * `getAvailableBackups` relies on for "newest first".
+ */
+export function encodeSnapshotId(isoTimestamp: string): string {
+  return isoTimestamp.replace(/:/g, "-");
 }
 
 /**
@@ -61,9 +84,11 @@ export async function snapshotPRDTree(rexDir: string): Promise<BackupSnapshot | 
     throw new Error(`Failed to create backups directory: ${String(err)}`);
   }
 
-  // Create timestamped backup directory
+  // Create timestamped backup directory. The id is colon-free so the mkdir
+  // succeeds on Windows — see encodeSnapshotId.
   const timestamp = new Date().toISOString();
-  const backupPath = join(backupsDir, `prd_tree_${timestamp}`);
+  const id = encodeSnapshotId(timestamp);
+  const backupPath = join(backupsDir, `prd_tree_${id}`);
 
   // Copy tree to backup location
   try {
@@ -72,7 +97,7 @@ export async function snapshotPRDTree(rexDir: string): Promise<BackupSnapshot | 
     throw new Error(`Failed to snapshot PRD tree to ${backupPath}: ${String(err)}`);
   }
 
-  return { timestamp, backupPath };
+  return { timestamp, id, backupPath };
 }
 
 /**
@@ -81,32 +106,66 @@ export async function snapshotPRDTree(rexDir: string): Promise<BackupSnapshot | 
  * This replaces the current prd_tree with the backed-up version.
  * The backup directory itself remains in `.rex/.backups/` for audit.
  *
+ * Restoring is a REPLACE, not an overlay: the current tree is deleted before
+ * the backup is copied in. An overlay (plain recursive copy with force) leaves
+ * behind any file the run created that the snapshot never had, so the tree
+ * ends up as a union of both states rather than the point-in-time it claims
+ * to be — which is worse than useless for a rollback.
+ *
  * @param rexDir      The `.rex/` directory
- * @param timestamp   ISO-8601 timestamp of the backup to restore
+ * @param id          Snapshot id from `getAvailableBackups`, or a raw ISO-8601
+ *                    timestamp (legacy snapshots created before the
+ *                    colon-encoding fix are still found).
  * @throws If the backup doesn't exist or restore fails
  */
-export async function restoreFromBackup(rexDir: string, timestamp: string): Promise<void> {
+export async function restoreFromBackup(rexDir: string, id: string): Promise<void> {
   const treeRoot = join(rexDir, "prd_tree");
   const backupsDir = join(rexDir, ".backups");
-  const backupPath = join(backupsDir, `prd_tree_${timestamp}`);
 
-  // Verify backup exists
-  const backupExists = await dirExists(backupPath);
-  if (!backupExists) {
-    throw new Error(`Backup not found at ${backupPath}`);
+  // Accept both the encoded id and a raw ISO timestamp. Snapshots written on
+  // Unix before the encoding fix still carry colons in their directory names.
+  const candidates = [
+    join(backupsDir, `prd_tree_${encodeSnapshotId(id)}`),
+    join(backupsDir, `prd_tree_${id}`),
+  ];
+
+  let backupPath: string | null = null;
+  for (const candidate of candidates) {
+    if (await dirExists(candidate)) {
+      backupPath = candidate;
+      break;
+    }
+  }
+  if (backupPath === null) {
+    throw new Error(`Backup not found at ${candidates[0]}`);
   }
 
-  // Remove current tree if it exists
+  // Stage the restore beside the live tree, then swap. Deleting the tree first
+  // and copying second would leave the project with no PRD at all if the copy
+  // failed halfway.
+  const stagingPath = join(backupsDir, `.restore_staging_${encodeSnapshotId(id)}`);
   try {
-    await stat(treeRoot);
-    // Tree exists, remove it
-    await cp(backupPath, treeRoot, { recursive: true, force: true });
-  } catch (err: any) {
-    if (err.code === "ENOENT") {
-      // Tree doesn't exist, just copy the backup
-      await cp(backupPath, treeRoot, { recursive: true });
-    } else {
-      throw new Error(`Failed to restore from backup: ${String(err)}`);
+    await rm(stagingPath, { recursive: true, force: true });
+    await cp(backupPath, stagingPath, { recursive: true });
+  } catch (err) {
+    await rm(stagingPath, { recursive: true, force: true }).catch(() => {});
+    throw new Error(`Failed to stage restore from backup: ${String(err)}`);
+  }
+
+  try {
+    await rm(treeRoot, { recursive: true, force: true });
+    await rename(stagingPath, treeRoot);
+  } catch (err) {
+    // rename can fail across devices; fall back to a copy so the restore still
+    // completes rather than leaving the tree missing.
+    try {
+      await cp(stagingPath, treeRoot, { recursive: true });
+      await rm(stagingPath, { recursive: true, force: true }).catch(() => {});
+    } catch {
+      throw new Error(
+        `Failed to restore from backup: ${String(err)}. ` +
+          `The snapshot is intact at ${backupPath} — copy it to ${treeRoot} manually.`,
+      );
     }
   }
 }

--- a/packages/rex/src/store/folder-tree-parser.ts
+++ b/packages/rex/src/store/folder-tree-parser.ts
@@ -604,7 +604,15 @@ async function parseItemFileFromFrontmatter(
 
 async function readIndexFile(filePath: string, warnings: ParseWarning[]): Promise<string | null> {
   try {
-    return await readFile(filePath, "utf8");
+    // Normalize CRLF → LF before any parsing. rex serializes with LF, but a
+    // Windows checkout without eol=lf pins (core.autocrlf=true) hands us CRLF.
+    // The line-based parsers below (frontmatter, body offsets, `## Subtask:`
+    // sections) split and match on "\n"; without this a trailing "\r" turns a
+    // block-style key like `tags:` into `tags:\r`, which silently aborts the
+    // frontmatter mapping and DROPS every remaining field — a data-loss bug on
+    // the next parse→save round trip, not just a cosmetic one.
+    const raw = await readFile(filePath, "utf8");
+    return raw.replace(/\r\n/g, "\n");
   } catch {
     warnings.push({ path: filePath, message: "index.md not found or unreadable" });
     return null;
@@ -884,7 +892,10 @@ export function parseFrontmatter(
   filePath: string,
   warnings: ParseWarning[],
 ): Record<string, unknown> | null {
-  const lines = text.split("\n");
+  // CRLF-tolerant split: external callers (folder-per-task-migration) pass raw
+  // file text that readIndexFile's normalization never saw. A retained "\r"
+  // breaks block-style key detection in splitMappingLine (see readIndexFile).
+  const lines = text.split(/\r?\n/);
 
   // Find opening ---
   let i = 0;

--- a/packages/rex/tests/e2e/cli-quiet.test.ts
+++ b/packages/rex/tests/e2e/cli-quiet.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
+import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -42,15 +43,15 @@ describe("rex --quiet", () => {
     const quiet = run(["init", "--quiet", tmpDir2]);
     expect(quiet).toBe("");
 
-    // Clean up
-    execFileSync("rm", ["-rf", tmpDir2]);
+    // Clean up — rmSync, not `rm`: there is no rm binary on Windows.
+    rmSync(tmpDir2, { recursive: true, force: true });
   });
 
   it("suppresses init output with -q shorthand", () => {
     const tmpDir2 = tmpDir + "-q2";
     const quiet = run(["init", "-q", tmpDir2]);
     expect(quiet).toBe("");
-    execFileSync("rm", ["-rf", tmpDir2]);
+    rmSync(tmpDir2, { recursive: true, force: true });
   });
 
   it("shows minimal status output with --quiet", () => {

--- a/packages/rex/tests/integration/backup-snapshots.test.ts
+++ b/packages/rex/tests/integration/backup-snapshots.test.ts
@@ -126,11 +126,13 @@ describe("backup-snapshots", () => {
     // Get list of backups
     const backups = await getAvailableBackups(rexDir);
 
-    // Verify all backups are listed and sorted (newest first)
+    // Verify all backups are listed and sorted (newest first). getAvailableBackups
+    // returns the on-disk snapshot id, which is the colon-free encoding of the
+    // ISO timestamp — not the raw timestamp.
     expect(backups.length).toBe(3);
-    expect(backups[0]).toBe(snapshots[2].timestamp);
-    expect(backups[1]).toBe(snapshots[1].timestamp);
-    expect(backups[2]).toBe(snapshots[0].timestamp);
+    expect(backups[0]).toBe(snapshots[2].id);
+    expect(backups[1]).toBe(snapshots[1].id);
+    expect(backups[2]).toBe(snapshots[0].id);
   });
 
   it("should prune old backups keeping only the retention cap", async () => {
@@ -226,5 +228,73 @@ describe("backup-snapshots", () => {
     const backupTaskFile = join(snapshot!.backupPath, "epic_nested", "feature_sub", "task_item", "index.md");
     const content = await readFile(backupTaskFile, "utf-8");
     expect(content).toBe("Nested task");
+  });
+
+  // ── Windows filename-safety regression ───────────────────────────────────────
+  //
+  // The snapshot directory name used to embed a raw ISO-8601 timestamp. `:` is
+  // illegal in Windows filenames, so every snapshot failed with EINVAL — and
+  // because callers downgraded the failure to a warning and continued, Windows
+  // users ran destructive tree rewrites with no rollback at all.
+
+  it("names the snapshot directory without characters Windows forbids", async () => {
+    await mkdir(join(treeRoot, "epic_test"), { recursive: true });
+    await writeFile(join(treeRoot, "epic_test", "index.md"), "Test");
+
+    const snapshot = await snapshotPRDTree(rexDir);
+    expect(snapshot).not.toBeNull();
+
+    const dirName = snapshot!.backupPath.split(/[\\/]/).pop()!;
+    // <>:"/\|?* are all reserved on Windows.
+    expect(dirName).not.toMatch(/[<>:"/\\|?*]/);
+    // The directory really exists — proves the mkdir/cp actually succeeded.
+    expect((await stat(snapshot!.backupPath)).isDirectory()).toBe(true);
+  });
+
+  it("keeps snapshot ids chronologically sortable after colon encoding", async () => {
+    await mkdir(join(treeRoot, "epic_test"), { recursive: true });
+    await writeFile(join(treeRoot, "epic_test", "index.md"), "Test");
+
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const snap = await snapshotPRDTree(rexDir);
+      ids.push(snap!.id);
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // getAvailableBackups relies on lexicographic sort meaning chronological
+    // order. Encoding must not break that.
+    expect([...ids].sort()).toEqual(ids);
+  });
+
+  it("restores from a raw ISO timestamp as well as an encoded id", async () => {
+    await mkdir(join(treeRoot, "epic_test"), { recursive: true });
+    await writeFile(join(treeRoot, "epic_test", "index.md"), "original");
+
+    const snapshot = await snapshotPRDTree(rexDir);
+    await writeFile(join(treeRoot, "epic_test", "index.md"), "mutated");
+
+    // Callers holding the ISO timestamp (the pre-fix identifier) still work.
+    await restoreFromBackup(rexDir, snapshot!.timestamp);
+    expect(await readFile(join(treeRoot, "epic_test", "index.md"), "utf-8")).toBe("original");
+  });
+
+  it("replaces the tree on restore rather than overlaying it", async () => {
+    await mkdir(join(treeRoot, "epic_test"), { recursive: true });
+    await writeFile(join(treeRoot, "epic_test", "index.md"), "original");
+
+    const snapshot = await snapshotPRDTree(rexDir);
+
+    // Simulate a command that ADDS an item after the snapshot was taken.
+    await mkdir(join(treeRoot, "epic_added"), { recursive: true });
+    await writeFile(join(treeRoot, "epic_added", "index.md"), "added later");
+
+    await restoreFromBackup(rexDir, snapshot!.id);
+
+    // A plain recursive copy would leave epic_added behind, producing a tree
+    // that is the union of both states instead of the snapshot's point in time.
+    const entries = await readdir(treeRoot);
+    expect(entries).toContain("epic_test");
+    expect(entries).not.toContain("epic_added");
   });
 });

--- a/packages/rex/tests/integration/prd-tree-canonical-migration.test.ts
+++ b/packages/rex/tests/integration/prd-tree-canonical-migration.test.ts
@@ -123,7 +123,8 @@ describe("PRD tree canonical migration", () => {
     // ── Snapshot before mutating ─────────────────────────────────────────────
     const snapshot = await snapshotPRDTree(rexDir);
     expect(snapshot).not.toBeNull();
-    expect(snapshot!.backupPath).toMatch(/\.rex\/\.backups\/prd_tree_/);
+    // [\\/]: backupPath is built with join(), so it uses "\" on Windows.
+    expect(snapshot!.backupPath).toMatch(/\.rex[\\/]\.backups[\\/]prd_tree_/);
     const backupExists = await stat(snapshot!.backupPath).then(() => true).catch(() => false);
     expect(backupExists).toBe(true);
 

--- a/packages/rex/tests/unit/store/ensure-legacy-prd-migrated.test.ts
+++ b/packages/rex/tests/unit/store/ensure-legacy-prd-migrated.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { ensureLegacyPrdMigrated, LegacyPrdMigrationError } from "../../../src/store/ensure-legacy-prd-migrated.js";
@@ -153,8 +153,9 @@ describe("ensureLegacyPrdMigrated", () => {
     expect(result.migrated).toBe(true);
     expect(result.backupPath).toBeDefined();
 
-    // Extract timestamp from filename and verify format
-    const backupName = result.backupPath!.split("/").pop()!;
+    // Extract timestamp from filename and verify format. basename, not
+    // split("/"): backupPath uses "\" separators on Windows.
+    const backupName = basename(result.backupPath!);
     expect(backupName).toMatch(/^prd\.json\.backup-\d{8}-\d{6}$/);
 
     // Verify backup contains original content

--- a/packages/rex/tests/unit/store/folder-tree-parser.test.ts
+++ b/packages/rex/tests/unit/store/folder-tree-parser.test.ts
@@ -293,7 +293,8 @@ describe("parseFolderTree: folder-tree fixtures", () => {
     expect(result.items.map(item => item.title)).toEqual(["Good Epic"]);
     expect(result.warnings).toEqual([
       expect.objectContaining({
-        path: expect.stringContaining("broken-epic-bbbbbbbb/index.md"),
+        // join() builds the warning path, so the separator is "\" on Windows.
+        path: expect.stringContaining(join("broken-epic-bbbbbbbb", "index.md")),
         message: "Unclosed frontmatter block (missing closing ---)",
       }),
     ]);

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -16,7 +16,54 @@
  *   7. changeset presence check
  */
 
-import { spawnTool } from "../packages/llm-client/dist/public.js";
+import { spawnCli } from "../packages/llm-client/dist/public.js";
+
+/** Per-step timeout. */
+const STEP_TIMEOUT_MS = 600_000;
+
+/** Grace period before escalating SIGTERM → SIGKILL on timeout. */
+const KILL_ESCALATION_MS = 5_000;
+
+/**
+ * Run one preflight step, inheriting stdio so the child's output streams live.
+ *
+ * Uses `spawnCli` rather than `spawnTool`: `spawnTool` calls `spawn()` directly,
+ * which on Windows cannot launch the `pnpm.CMD` shim — the child emits an
+ * `error` event that surfaced as a bare `exitCode: 1` with no output at all.
+ * `spawnCli` routes through cmd.exe on win32 and does a plain `spawn` on
+ * macOS/Linux, where `pnpm` is a real executable on PATH.
+ *
+ * Resolves with the exit code (null when killed by the timeout).
+ */
+function runStep(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawnCli(cmd, args, { cwd: process.cwd(), stdio: "inherit" });
+
+    let settled = false;
+    let killTimer;
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), KILL_ESCALATION_MS);
+      if (!settled) {
+        settled = true;
+        reject(new Error(`timed out after ${STEP_TIMEOUT_MS / 1000}s`));
+      }
+    }, STEP_TIMEOUT_MS);
+
+    const finish = (fn, value) => {
+      clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+      if (settled) return;
+      settled = true;
+      fn(value);
+    };
+
+    // On win32 the child is cmd.exe, which spawns fine even when the target
+    // binary is missing — that surfaces as a non-zero exit, not an error event.
+    child.on("error", (err) => finish(reject, err));
+    child.on("close", (code) => finish(resolve, code));
+  });
+}
 
 const steps = [
   { name: "obfuscated-code", cmd: "pnpm security:obfuscation" },
@@ -33,17 +80,15 @@ for (const { name, cmd } of steps) {
   process.stdout.write(`\n── ${name} ──\n`);
   try {
     const [tool, ...args] = cmd.split(" ");
-    const result = await spawnTool(tool, args, {
-      cwd: process.cwd(),
-      stdio: "inherit",
-      timeout: 600_000,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(`${cmd} exited with code ${result.exitCode}`);
+    const exitCode = await runStep(tool, args);
+    if (exitCode !== 0) {
+      throw new Error(`${cmd} exited with code ${exitCode}`);
     }
     console.log(`  ✓ ${name}`);
-  } catch {
-    console.error(`  ✗ ${name} FAILED`);
+  } catch (err) {
+    // Surface the reason — a swallowed message here made a spawn failure look
+    // identical to a genuine step failure.
+    console.error(`  ✗ ${name} FAILED — ${err?.message ?? err}`);
     failed = true;
     break;
   }

--- a/tests/e2e/architecture-policy.test.js
+++ b/tests/e2e/architecture-policy.test.js
@@ -1229,12 +1229,13 @@ const DOCUMENTED_DYNAMIC_IMPORTS = new Map([
   ["packages/rex/src/cli/commands/remove.ts", "Lazy-loads LLM client for smart remove analysis"],
   ["packages/rex/src/cli/commands/reorganize.ts", "Lazy-loads LLM client for reorganization proposals"],
   ["packages/rex/src/cli/commands/reshape.ts", "Lazy-loads LLM client for reshape analysis"],
+  ["packages/rex/src/cli/commands/restore.ts", "Lazy-loads node:readline only for the interactive restore confirmation prompt — skipped entirely with --yes"],
   ["packages/rex/src/cli/commands/smart-add.ts", "Lazy-loads LLM client for smart add proposals"],
   ["packages/rex/src/cli/commands/validate-interactive.ts", "Lazy-loads LLM client for interactive validation"],
   ["packages/rex/src/cli/commands/verify.ts", "Lazy-loads LLM client for verify analysis"],
   // Core — lazy-loads utilities
   ["packages/core/config.js", "Lazy-loads llm-client vendor reset helpers when the vendor changes, plus the shared auth-failure guidance and the cli-brand color palette on the preflight-failure error path"],
-  ["packages/core/cli.js", "Lazy-loads cli-ink.js (Ink + React TTY renderer) only during `ndx init` in interactive TTY mode — avoids React/Ink bundle cost for every CLI invocation"],
+  ["packages/core/cli.js", "Lazy-loads cli-ink.js (Ink + React TUI renderer) only during `ndx init` when stdout is a TTY and --quiet is unset — avoids React/Ink import cost on every CLI invocation and in non-interactive environments"],
   ["packages/rex/src/cli/mcp-tools.ts", "Lazy-loads MCP tool handlers on demand"],
   ["packages/rex/src/analyze/reason.ts", "Lazy-loads LLM client for reason analysis"],
   // Sourcevision — lazy-loads analyzers and heavy dependencies
@@ -1250,8 +1251,6 @@ const DOCUMENTED_DYNAMIC_IMPORTS = new Map([
   ["packages/web/src/server/routes-rex/health.ts", "Lazy-loads health check analysis on demand"],
   // Core orchestrator — dynamic import of rex public API for export pre-rendering
   ["packages/core/export.js", "Lazy-loads rex functions for static export pre-rendering"],
-  // Core CLI — lazy-loads Ink TUI renderer only when running in an interactive TTY
-  ["packages/core/cli.js", "Lazy-loads cli-ink.js Ink TUI renderer on demand — only activated when stdout is a TTY, avoiding React/Ink import cost in non-interactive environments"],
   // Hench agent — deferred node: builtins for lock file and cleanup operations
   ["packages/hench/src/agent/lifecycle/shared.ts", "Lazy-loads node:fs and node:path for lock file cleanup — deferred to avoid import overhead on code paths that never touch the filesystem"],
   ["packages/hench/src/tools/cleanup-transformations.ts", "Lazy-loads node:fs/promises for file deletion — async filesystem access isolated to the tool cleanup path"],

--- a/tests/e2e/prd-line-endings.test.js
+++ b/tests/e2e/prd-line-endings.test.js
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { closeSync, openSync, readdirSync, readFileSync, readSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { GITATTRIBUTES_EOL_RULES } from "../../packages/core/gitattributes-pins.js";
 
@@ -108,14 +108,34 @@ describe("other n-dx-serialized tracked files are pinned to LF", () => {
 // two sources diverged (one was updated, the other wasn't), so a per-pattern
 // check isn't enough — assert the FULL pattern sets are equal.
 describe("GITATTRIBUTES_EOL_RULES stays in sync with n-dx's own .gitattributes", () => {
-  /** First-token glob pattern of each `eol=lf` line in a .gitattributes body. */
+  /**
+   * Marker that ends the injector-managed region of .gitattributes. Pins below
+   * it are specific to this repo's layout (shebang scripts, bin entries) and are
+   * deliberately absent from GITATTRIBUTES_EOL_RULES, which `ndx init` writes
+   * into consumer projects that have no such files.
+   */
+  const REPO_ONLY_MARKER = "# repo-only eol pins (not injected by ndx init)";
+
+  /**
+   * First-token glob pattern of each `eol=lf` line in a .gitattributes body,
+   * limited to the injector-managed region above {@link REPO_ONLY_MARKER}.
+   */
   function eolPatternsFromGitattributes(body) {
-    return body
+    const injectorRegion = body.split(REPO_ONLY_MARKER)[0];
+    return injectorRegion
       .split("\n")
       .map((line) => line.trim())
       .filter((line) => line && !line.startsWith("#") && line.includes("eol=lf"))
       .map((line) => line.split(/\s+/)[0]);
   }
+
+  it("the repo-only marker is present so the guard scopes the right region", () => {
+    const repoBody = readFileSync(join(REPO_ROOT, ".gitattributes"), "utf-8");
+    // If the marker is renamed or dropped, eolPatternsFromGitattributes silently
+    // widens to the whole file and this suite starts failing for the wrong
+    // reason. Assert it explicitly so the cause is obvious.
+    expect(repoBody).toContain(REPO_ONLY_MARKER);
+  });
 
   it("the injected rule set equals the repo .gitattributes eol=lf pattern set", () => {
     const injectorPatterns = GITATTRIBUTES_EOL_RULES.map((r) => r.trim().split(/\s+/)[0]);
@@ -137,5 +157,70 @@ describe("GITATTRIBUTES_EOL_RULES stays in sync with n-dx's own .gitattributes",
       readFileSync(join(REPO_ROOT, ".gitattributes"), "utf-8"),
     );
     expect(repoPatterns.length).toBe(new Set(repoPatterns).size);
+  });
+});
+
+// ── Shebang files must be LF ────────────────────────────────────────────────
+// A `#!...\r\n` shebang is broken two ways: Unix refuses to execute the file
+// ("bad interpreter: /usr/bin/env node^M"), and vitest's module transform emits
+// unparseable code for it, so any test importing such a script dies at
+// collection with a locationless `SyntaxError: Invalid or unexpected token`.
+// Linux CI never sees this — the index is LF — so only Windows checkouts
+// (core.autocrlf=true) hit it. These assertions are platform-independent: they
+// read git's resolved attribute, not the working-tree bytes.
+describe("hashbang-bearing tracked files are pinned to LF", () => {
+  /** Tracked files whose first two bytes are `#!`. */
+  function trackedShebangFiles() {
+    const tracked = execFileSync("git", ["ls-files"], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      maxBuffer: 32 * 1024 * 1024,
+    })
+      .split("\n")
+      .filter(Boolean);
+
+    return tracked.filter((rel) => {
+      try {
+        // Read the first two bytes only — cheaper than loading every file, and
+        // avoids one git process per file (which is too slow for a test).
+        const fd = openSync(join(REPO_ROOT, rel), "r");
+        try {
+          const buf = Buffer.alloc(2);
+          readSync(fd, buf, 0, 2, 0);
+          return buf[0] === 0x23 && buf[1] === 0x21; // "#!"
+        } finally {
+          closeSync(fd);
+        }
+      } catch {
+        return false; // unreadable or deleted in the working tree
+      }
+    });
+  }
+
+  const shebangFiles = trackedShebangFiles();
+
+  it("finds hashbang files to validate", () => {
+    expect(shebangFiles.length).toBeGreaterThan(0);
+  });
+
+  it("git resolves eol=lf for every hashbang file", () => {
+    // One batched check-attr call: `--stdin` reads the whole path list at once.
+    const out = execFileSync("git", ["check-attr", "eol", "--stdin"], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      input: shebangFiles.join("\n"),
+      maxBuffer: 32 * 1024 * 1024,
+    });
+
+    const unpinned = out
+      .split("\n")
+      .filter((line) => line.trim() && !line.endsWith(": lf"))
+      .map((line) => line.split(":")[0]);
+
+    expect(
+      unpinned,
+      "add an eol=lf pin in .gitattributes for these shebang files — a CRLF " +
+        "shebang breaks Unix execution and vitest's transform",
+    ).toEqual([]);
   });
 });

--- a/tests/e2e/published-assets-bundled.test.js
+++ b/tests/e2e/published-assets-bundled.test.js
@@ -8,9 +8,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+// execFileSyncCli, not execFileSync: `pnpm` on Windows is a `.CMD` shim, which a
+// raw execFileSync cannot launch (`spawnSync pnpm ENOENT`). The helper routes
+// through cmd.exe on win32 and calls execFileSync directly elsewhere.
+import { execFileSyncCli } from "../../packages/core/win-spawn.js";
 
 const CORE_DIR = join(import.meta.dirname, "../../packages/core");
 const ASSET_DIR = join(CORE_DIR, "assistant-assets");
@@ -37,7 +40,7 @@ describe("@n-dx/core publishes assistant-assets/", () => {
     // pnpm (not npm): npm rebuilds shared dist via the `prepare` lifecycle on
     // pack even with ignore-scripts, racing other root tests. pnpm honors
     // .npmrc ignore-scripts=true. `pnpm pack --json` prints a single object.
-    const out = execFileSync(
+    const out = execFileSyncCli(
       "pnpm",
       ["pack", "--dry-run", "--json"],
       { cwd: CORE_DIR, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },

--- a/tests/e2e/published-package-loadability.test.js
+++ b/tests/e2e/published-package-loadability.test.js
@@ -12,6 +12,10 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execFileSync, spawnSync } from "child_process";
+// execFileSyncCli is used for `pnpm` only: on Windows pnpm is a `.CMD` shim that
+// a raw execFileSync cannot launch (`spawnSync pnpm ENOENT`). `tar` and `node`
+// are real executables, so they keep using execFileSync/spawnSync directly.
+import { execFileSyncCli } from "../../packages/core/win-spawn.js";
 import {
   mkdtempSync,
   rmSync,
@@ -24,6 +28,17 @@ import {
 } from "fs";
 import { join, resolve, dirname } from "path";
 import { tmpdir } from "os";
+import { pathToFileURL } from "url";
+
+/**
+ * Render a path as a `file://` URL literal for embedding in generated `import()`
+ * code. Windows rejects a bare absolute path there with
+ * ERR_UNSUPPORTED_ESM_URL_SCHEME ("Received protocol 'c:'"); posix accepts the
+ * file:// form too, so this is unconditional.
+ */
+function importSpecifier(path) {
+  return JSON.stringify(pathToFileURL(path).href);
+}
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
 const PACKAGES_DIR = join(REPO_ROOT, "packages");
@@ -65,7 +80,7 @@ function packAndExtract(pkgDir) {
   // CLIs (e.g. a concurrent `rex prune` loading a half-written module). pnpm
   // honors ignore-scripts=true, so it packs the pre-built dist/ (what publish
   // ships) without rebuilding.
-  const out = execFileSync(
+  const out = execFileSyncCli(
     "pnpm",
     ["pack", "--json", "--pack-destination", tmpRoot],
     { cwd: pkgDir, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
@@ -86,7 +101,14 @@ function packAndExtract(pkgDir) {
   // to test transitive workspace deps — those come from the source tree.
   const srcNodeModules = join(pkgDir, "node_modules");
   if (existsSync(srcNodeModules)) {
-    symlinkSync(srcNodeModules, join(extractDir, "node_modules"));
+    // "junction" on Windows: a directory symlink requires elevation or Developer
+    // Mode there and otherwise fails with EPERM. Junctions need no privileges and
+    // behave the same for module resolution. The type arg is ignored off-Windows.
+    symlinkSync(
+      srcNodeModules,
+      join(extractDir, "node_modules"),
+      process.platform === "win32" ? "junction" : undefined,
+    );
   }
 
   return { tmpRoot, extractDir, shippedFiles: report.files.map((f) => f.path) };
@@ -141,7 +163,7 @@ describe("published-package loadability (pack + extract + import)", () => {
           const result = runNode([
             "--input-type=module",
             "-e",
-            `await import(${JSON.stringify(entryPath)});`,
+            `await import(${importSpecifier(entryPath)});`,
           ]);
 
           if (result.status !== 0) {
@@ -227,7 +249,7 @@ describe("published-package loadability (pack + extract + import)", () => {
         "--input-type=module",
         "-e",
         `
-          const m = await import(${JSON.stringify(join(extractDir, "assistant-assets.js"))});
+          const m = await import(${importSpecifier(join(extractDir, "assistant-assets.js"))});
           const manifest = m.getManifest();
           if (!manifest.skills || Object.keys(manifest.skills).length === 0) {
             throw new Error("manifest.skills is empty");
@@ -254,7 +276,7 @@ describe("published-package loadability (pack + extract + import)", () => {
       const result = runNode([
         "--input-type=module",
         "-e",
-        `await import(${JSON.stringify(join(extractDir, "claude-integration.js"))});`,
+        `await import(${importSpecifier(join(extractDir, "claude-integration.js"))});`,
       ]);
       if (result.status !== 0) {
         throw new Error(
@@ -267,7 +289,7 @@ describe("published-package loadability (pack + extract + import)", () => {
       const result = runNode([
         "--input-type=module",
         "-e",
-        `await import(${JSON.stringify(join(extractDir, "codex-integration.js"))});`,
+        `await import(${importSpecifier(join(extractDir, "codex-integration.js"))});`,
       ]);
       if (result.status !== 0) {
         throw new Error(

--- a/tests/unit/update-check.test.js
+++ b/tests/unit/update-check.test.js
@@ -25,6 +25,8 @@ import { readFile, writeFile } from "node:fs/promises";
 import {
   startUpdateCheck,
   formatUpdateNotice,
+  detectInstallManager,
+  formatUpgradeCommand,
   CACHE_TTL_MS,
 } from "../../packages/core/update-check.js";
 
@@ -190,6 +192,74 @@ describe("update-check", () => {
     it("includes the install command in the output", () => {
       const notice = formatUpdateNotice({ current: "1.0.0", latest: "2.0.0" });
       expect(notice).toMatch(/npm|pnpm|install|update/i);
+    });
+
+    it("suggests the command for the detected package manager", () => {
+      const notice = formatUpdateNotice({
+        current: "1.0.0",
+        latest: "2.0.0",
+        manager: "pnpm",
+      });
+      expect(notice).toContain("pnpm add -g @n-dx/core@latest");
+      expect(notice).not.toContain("npm i -g");
+    });
+
+    // Regression: a bare `@n-dx/core` re-resolves inside pnpm's recorded caret
+    // range, which for 0.x versions cannot cross a minor boundary. Users stayed
+    // stranded on 0.3.x while believing they had upgraded.
+    it("always pins @latest so a caret range cannot strand the upgrade", () => {
+      for (const manager of ["npm", "pnpm", "yarn"]) {
+        const notice = formatUpdateNotice({ current: "0.3.1", latest: "0.4.6", manager });
+        expect(notice).toContain("@n-dx/core@latest");
+      }
+    });
+  });
+
+  describe("detectInstallManager", () => {
+    it("detects a pnpm global install from its virtual store path", () => {
+      expect(
+        detectInstallManager(
+          "C:\\Users\\x\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\@n-dx+core@0.3.1\\node_modules\\@n-dx\\core\\update-check.js",
+        ),
+      ).toBe("pnpm");
+    });
+
+    it("detects pnpm on POSIX paths", () => {
+      expect(
+        detectInstallManager("/home/x/.local/share/pnpm/global/5/.pnpm/@n-dx+core@0.4.6/node_modules/@n-dx/core/update-check.js"),
+      ).toBe("pnpm");
+    });
+
+    it("detects a yarn classic global install", () => {
+      expect(
+        detectInstallManager(
+          "C:\\Users\\x\\AppData\\Local\\Yarn\\Data\\global\\node_modules\\@n-dx\\core\\update-check.js",
+        ),
+      ).toBe("yarn");
+    });
+
+    it("falls back to npm for an npm prefix install", () => {
+      expect(
+        detectInstallManager(
+          "C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\@n-dx\\core\\update-check.js",
+        ),
+      ).toBe("npm");
+    });
+
+    it("falls back to npm for a local dev checkout", () => {
+      expect(detectInstallManager("/home/x/code/n-dx/packages/core/update-check.js")).toBe("npm");
+    });
+  });
+
+  describe("formatUpgradeCommand", () => {
+    it("maps each manager to its own global-install syntax", () => {
+      expect(formatUpgradeCommand("npm")).toBe("npm i -g @n-dx/core@latest");
+      expect(formatUpgradeCommand("pnpm")).toBe("pnpm add -g @n-dx/core@latest");
+      expect(formatUpgradeCommand("yarn")).toBe("yarn global add @n-dx/core@latest");
+    });
+
+    it("treats an unknown manager as npm", () => {
+      expect(formatUpgradeCommand("bun")).toBe("npm i -g @n-dx/core@latest");
     });
   });
 

--- a/tests/unit/win-spawn.test.js
+++ b/tests/unit/win-spawn.test.js
@@ -57,10 +57,16 @@ describe("quoteWindowsToken", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildWindowsCliCommandLine", () => {
-  it("joins binary and args as quoted tokens", () => {
+  it("quotes args and leaves a bare binary name unquoted", () => {
     expect(buildWindowsCliCommandLine("node", ["--version"])).toBe(
-      '"node" "--version"',
+      'node "--version"',
     );
+  });
+
+  // A quoted command name defeats cmd.exe PATHEXT resolution — see the
+  // rationale on buildWindowsCliCommandLine in packages/llm-client/src/exec.ts.
+  it("leaves bare names unquoted so cmd.exe PATHEXT resolution still applies", () => {
+    expect(buildWindowsCliCommandLine("pnpm", ["build"])).toBe('pnpm "build"');
   });
 
   it("handles a spaced binary path", () => {
@@ -69,7 +75,7 @@ describe("buildWindowsCliCommandLine", () => {
   });
 
   it("handles zero args", () => {
-    expect(buildWindowsCliCommandLine("claude", [])).toBe('"claude"');
+    expect(buildWindowsCliCommandLine("claude", [])).toBe("claude");
   });
 });
 


### PR DESCRIPTION
This PR addresses a critical issue where PRD tree backups were silently failing on Windows systems due to filesystem naming restrictions. Additionally, it introduces a robust "Snapshot" system for the rex package, allowing users to safely perform structural migrations (like reshapes or moves) with a reliable rollback mechanism.

**The Problem**
The rex package generates backup snapshots using ISO-8601 timestamps (e.g., 2026-08-05T17:27:18Z). Because Windows forbids colons (:) in filenames, the mkdir operation for these backups would fail with EINVAL.

While the failure was caught and downgraded to a warning, this meant Windows users were receiving zero backup coverage, leaving their PRD data vulnerable during complex operations.

**The Solution**
Windows-Safe Encoding: Introduced encodeSnapshotId which replaces colons with hyphens. This preserves lexicographical ordering (ensuring "newest first" logic still works) while making the IDs filesystem-safe on all platforms.
Atomic Snapshotting: Implemented snapshotPRDTree and restoreFromBackup logic. The restore process uses a "Stage-and-Swap" strategy:
Copies the backup to a temporary .restore_staging_ directory.
Deletes the current live tree.
Renames the staging directory to the live tree.
Fallback: If renaming fails (e.g., across different drives), it falls back to a recursive copy to ensure the restoration completes.
Retention Management: Added pruneBackups to automatically manage disk space by keeping only the most recent snapshots (default: 10).
CLI Integration: Updated add, fix, move, prune, remove, reorganize, and reshape commands to integrate with the new backup lifecycle.

**Key Features**
Safe Migrations: Users can now run rex reshape or rex reorganize with the confidence that they can revert to a point-in-time snapshot if the result isn't as expected.
Automatic Housekeeping: The pruning logic ensures the .rex/.backups folder doesn't grow indefinitely.
Backward Compatibility: The restore logic is designed to recognize both the new colon-free IDs and legacy Unix-style IDs.

**Testing & Verification**
Integration Tests: Added new tests in packages/rex/tests/integration/backup-snapshots.test.ts covering:
Successful snapshot creation.
Successful restoration from a snapshot.
Handling of missing backups.
Pruning logic verification.
Manual Verification: Verified that mkdir no longer throws EINVAL on Windows environments when using timestamped IDs.
**Affected Files**
- packages/rex/src/core/backup-snapshots.ts (Core logic)
- packages/rex/src/cli/commands/* (CLI integration)
- packages/rex/tests/integration/backup-snapshots.test.ts (New tests)
- docs/guide/troubleshooting.md (Updated documentation)
- README.md (Updated usage instructions)
Type of Change:

 Bug fix (Windows compatibility)
 New feature (Snapshots & Pruning)
 Documentation update