### PR TITLE
fix(ci): drop unsupported --access flag from changeset publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm exec changeset version
-          publish: pnpm exec changeset publish --access public
+          publish: pnpm exec changeset publish
           title: "chore: version packages"
           commit: "chore: version packages"
         env:


### PR DESCRIPTION
changeset publish (cac-based CLI) rejects unknown options, so the release job died with CACError before publishing. Public access is already set in .changeset/config.json and each package's publishConfig.