### PR TITLE
Route mechanical single-shot LLM calls to the light model tier

### DIFF
--- a/.changeset/light-tier-mechanical-calls.md
+++ b/.changeset/light-tier-mechanical-calls.md
@@ -1,0 +1,6 @@
+---
+"@n-dx/rex": patch
+"@n-dx/hench": patch
+---
+
+Route mechanical single-shot LLM calls to the light model tier. In rex, `spawnClaude()` gains an optional task-weight parameter (default `"standard"`), and sibling renames, group renames, body merges, the consolidation guard, the granularity assessment pass, guided clarify rounds, and the post-prune consolidation pass now resolve the vendor's light-tier model (e.g. haiku) when no explicit model is given. In hench, pre-run commit-message generation resolves the light tier instead of the run's standard model. An explicit `--model` flag (or a per-vendor `lightModel` config for the light tier) still overrides tier resolution, and the active tier is surfaced in vendor-header/spinner output ("light tier").

--- a/packages/hench/src/agent/lifecycle/shared.ts
+++ b/packages/hench/src/agent/lifecycle/shared.ts
@@ -1138,8 +1138,17 @@ async function promptPreRunCommitChoice(opts: PreRunPromptOptions): Promise<PreR
  * Best-effort LLM commit subject for pre-existing changes. Falls back to a
  * deterministic message when no provider/credentials are available or the
  * call fails — the gate must never block or error on message generation.
+ *
+ * Commit-message generation is a mechanical single-shot call, so it runs on
+ * the vendor's light tier (e.g. haiku) rather than the run's standard model.
+ * The caller passes the run's resolved model; when that matches the
+ * config-derived standard resolution (i.e. no explicit --model override was
+ * given), the light tier is used instead. A model that differs from the
+ * standard resolution is an explicit operator override and is honored as-is.
+ *
+ * Exported for testing.
  */
-async function proposePreRunCommitMessage(
+export async function proposePreRunCommitMessage(
   diff: ReviewDiff,
   henchDir: string,
   model?: string,
@@ -1147,7 +1156,16 @@ async function proposePreRunCommitMessage(
   try {
     const llmConfig = await loadLLMConfig(henchDir);
     const provider = defaultRegistry.getActiveProvider(llmConfig);
-    const resolvedModel = model ?? resolveVendorModel(resolveLLMVendor(llmConfig), llmConfig);
+    const vendor = resolveLLMVendor(llmConfig);
+    const standardModel = resolveVendorModel(vendor, llmConfig);
+    const isExplicitOverride = Boolean(model) && model !== standardModel;
+    const resolvedModel = isExplicitOverride
+      ? (model as string)
+      : resolveVendorModel(vendor, llmConfig, "light");
+    if (!isExplicitOverride) {
+      // Tier visibility — mirrors the vendor header's "(light tier)" label.
+      detail(`Commit message model: ${resolvedModel} (light tier)`);
+    }
     const prompt =
       "Write a single-line git commit subject (max 72 chars, conventional-commit " +
       "style, no body, no surrounding quotes or backticks) summarizing these " +

--- a/packages/hench/tests/unit/agent/lifecycle/pre-run-commit-message.test.ts
+++ b/packages/hench/tests/unit/agent/lifecycle/pre-run-commit-message.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for light-tier model routing in the pre-run commit-message
+ * generation path (proposePreRunCommitMessage).
+ *
+ * Commit-message generation is a mechanical single-shot call, so it should
+ * resolve the vendor's light-tier model instead of the run's standard model.
+ * The gate passes the run's resolved model in; when that value matches the
+ * config-derived standard resolution (no explicit --model override), the
+ * light tier is used. A differing model is an explicit override and wins.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { proposePreRunCommitMessage } from "../../../../src/agent/lifecycle/shared.js";
+import { defaultRegistry, TIER_MODELS, NEWEST_MODELS } from "../../../../src/prd/llm-gateway.js";
+import type { ReviewDiff } from "../../../../src/agent/analysis/review.js";
+
+const diff: ReviewDiff = {
+  stat: " 1 file changed, 2 insertions(+)",
+  diff: "diff --git a/x.ts b/x.ts\n+added line\n",
+};
+
+describe("proposePreRunCommitMessage light-tier routing", () => {
+  let tmpDir: string;
+  let henchDir: string;
+  let capturedModels: Array<string | undefined>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "hench-commit-msg-"));
+    henchDir = join(tmpDir, ".hench");
+    capturedModels = [];
+    vi.spyOn(defaultRegistry, "getActiveProvider").mockReturnValue({
+      complete: async ({ model }: { prompt: string; model?: string }) => {
+        capturedModels.push(model);
+        return { text: "feat: add a line to x" };
+      },
+    } as never);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("uses the light-tier model when the passed model is the standard resolution", async () => {
+    // The gate passes the run's resolved model — the config-derived standard
+    // model when no --model flag was given.
+    const message = await proposePreRunCommitMessage(diff, henchDir, NEWEST_MODELS.claude);
+
+    expect(capturedModels).toEqual([TIER_MODELS.claude.light]);
+    expect(message).toBe("feat: add a line to x");
+  });
+
+  it("uses the light-tier model when no model is passed at all", async () => {
+    await proposePreRunCommitMessage(diff, henchDir);
+
+    expect(capturedModels).toEqual([TIER_MODELS.claude.light]);
+  });
+
+  it("honors an explicit model override (differs from the standard resolution)", async () => {
+    await proposePreRunCommitMessage(diff, henchDir, "claude-opus-4-7");
+
+    expect(capturedModels).toEqual(["claude-opus-4-7"]);
+  });
+
+  it("honors a configured lightModel for the light tier", async () => {
+    await writeFile(
+      join(tmpDir, ".n-dx.json"),
+      JSON.stringify({
+        llm: { vendor: "claude", claude: { lightModel: "claude-custom-light" } },
+      }),
+      "utf-8",
+    );
+
+    await proposePreRunCommitMessage(diff, henchDir, NEWEST_MODELS.claude);
+
+    expect(capturedModels).toEqual(["claude-custom-light"]);
+  });
+
+  it("falls back to the deterministic message when the provider errors", async () => {
+    vi.spyOn(defaultRegistry, "getActiveProvider").mockImplementation(() => {
+      throw new Error("no credentials");
+    });
+
+    const message = await proposePreRunCommitMessage(diff, henchDir);
+
+    expect(message).toBe("chore: commit local changes before hench run");
+  });
+});

--- a/packages/rex/src/analyze/consolidation-guard.ts
+++ b/packages/rex/src/analyze/consolidation-guard.ts
@@ -106,6 +106,9 @@ ${OUTPUT_INSTRUCTION}`;
  * If the total task count exceeds the configured ceiling, triggers a
  * secondary LLM consolidation pass. If the LLM cannot reduce below the
  * ceiling, the best-effort result is returned with a warning.
+ *
+ * Mechanical single-shot call: when no explicit model is given, routes to the
+ * vendor's light-tier model (e.g. haiku) instead of the standard tier.
  */
 export async function applyConsolidationGuard(
   proposals: Proposal[],
@@ -136,7 +139,7 @@ export async function applyConsolidationGuard(
     originalTaskCount,
   );
 
-  const result = await spawnClaude(prompt, model);
+  const result = await spawnClaude(prompt, model, undefined, "light");
   accumulateTokenUsage(tokenUsage, result.tokenUsage);
 
   const consolidated = parseProposalResponse(result.text);

--- a/packages/rex/src/analyze/guided.ts
+++ b/packages/rex/src/analyze/guided.ts
@@ -180,6 +180,10 @@ export async function runGuidedSpec(
   model?: string,
 ): Promise<ReasonResult> {
   const effectiveModel = resolveConfiguredModel(model);
+  // Clarify rounds are mechanical single-shot calls (question generation) —
+  // route them to the light tier. Spec synthesis stays on the standard model.
+  // An explicit --model flag overrides both.
+  const clarifyModel = resolveConfiguredModel(model, "light");
   const tokenUsage = emptyAnalyzeTokenUsage();
 
   info("Guided spec builder — let's define your project.\n");
@@ -199,7 +203,7 @@ export async function runGuidedSpec(
   // Clarification loop
   for (let round = 0; round < MAX_CLARIFY_ROUNDS; round++) {
     info("\nAnalyzing your project...");
-    const response = await clarify(context, projectContext, effectiveModel);
+    const response = await clarify(context, projectContext, clarifyModel);
 
     if (response.status === "ready") {
       if (response.summary) {

--- a/packages/rex/src/analyze/llm-bridge.ts
+++ b/packages/rex/src/analyze/llm-bridge.ts
@@ -132,8 +132,18 @@ function getClient(): ClaudeClient {
  * @param model   Optional model override. When omitted, resolves from the
  *                active vendor via the centralized vendor/model resolver.
  * @param claudeConfig  Optional config override (creates a one-off client)
+ * @param weight  Task weight for tier-based model selection when no explicit
+ *                model is given. Mechanical single-shot calls (renames, body
+ *                merges, granularity assessment) pass "light" to route to the
+ *                vendor's light tier. Defaults to "standard" so untouched
+ *                call sites are unaffected. An explicit `model` always wins.
  */
-export async function spawnClaude(prompt: string, model?: string, claudeConfig?: ClaudeConfig): Promise<ClaudeResult> {
+export async function spawnClaude(
+  prompt: string,
+  model?: string,
+  claudeConfig?: ClaudeConfig,
+  weight: TaskWeight = "standard",
+): Promise<ClaudeResult> {
   // When an explicit config is passed, create a one-off client for it
   // instead of using the module-level client.
   const client = claudeConfig
@@ -146,7 +156,7 @@ export async function spawnClaude(prompt: string, model?: string, claudeConfig?:
     })
     : getClient();
 
-  const result = await client.complete({ prompt, model: resolveConfiguredModel(model) });
+  const result = await client.complete({ prompt, model: resolveConfiguredModel(model, weight) });
   return {
     text: result.text,
     tokenUsage: result.tokenUsage,

--- a/packages/rex/src/analyze/propose-group-renames.ts
+++ b/packages/rex/src/analyze/propose-group-renames.ts
@@ -145,6 +145,9 @@ export function buildGroupRenamePrompt(group: GroupRenameInput): string {
  * used as a deterministic fallback, guaranteeing uniqueness because hash
  * suffixes were already distinct before consolidation.
  *
+ * Mechanical single-shot call: when no explicit model is given, resolves the
+ * vendor's light-tier model (e.g. haiku) instead of the standard tier.
+ *
  * @throws {Error} When the LLM call fails or the response cannot be parsed.
  *   Callers must catch and degrade gracefully (children keep existing titles).
  */
@@ -164,7 +167,7 @@ export async function proposeGroupRenames(
 
   const subgroup: GroupRenameInput = { ...group, members: membersToRename };
   const prompt = buildGroupRenamePrompt(subgroup);
-  const resolvedModel = resolveConfiguredModel(model);
+  const resolvedModel = resolveConfiguredModel(model, "light");
 
   const llmResult = await spawnClaude(prompt, resolvedModel);
   const jsonText = extractJson(llmResult.text);

--- a/packages/rex/src/analyze/reason.ts
+++ b/packages/rex/src/analyze/reason.ts
@@ -1478,6 +1478,9 @@ export function formatAssessment(assessments: GranularityAssessment[]): string {
 /**
  * Assess the granularity of proposals by calling the LLM.
  * Returns assessments with recommendations and reasoning for each proposal.
+ *
+ * Mechanical single-shot call: when no explicit model is given, routes to the
+ * vendor's light-tier model (e.g. haiku) instead of the standard tier.
  */
 export async function assessGranularity(
   proposals: Proposal[],
@@ -1490,7 +1493,7 @@ export async function assessGranularity(
   }
 
   const prompt = buildAssessmentPrompt(proposals);
-  const result = await spawnClaude(prompt, model);
+  const result = await spawnClaude(prompt, model, undefined, "light");
   accumulateTokenUsage(tokenUsage, result.tokenUsage);
 
   const assessments = parseAssessmentResponse(result.text, proposals);

--- a/packages/rex/src/analyze/rename-resolve.ts
+++ b/packages/rex/src/analyze/rename-resolve.ts
@@ -87,9 +87,12 @@ Respond with JSON only (no markdown wrapper, no prose):
 /**
  * Invoke the LLM to propose distinct titles for two siblings that share a title.
  *
+ * Mechanical single-shot call: when no explicit model is given, resolves the
+ * vendor's light-tier model (e.g. haiku) instead of the standard tier.
+ *
  * @param itemA - First colliding sibling.
  * @param itemB - Second colliding sibling.
- * @param model - Optional model override (falls back to configured default).
+ * @param model - Optional model override (falls back to the light-tier model).
  * @returns A rename proposal with new titles and reasoning.
  * @throws {Error} If the LLM call fails, the response is unparseable, or the
  *   proposed titles still collide with each other.
@@ -100,7 +103,7 @@ export async function proposeSiblingRenames(
   model?: string,
 ): Promise<SiblingRenameProposal> {
   const prompt = buildRenamePrompt(itemA, itemB);
-  const resolvedModel = resolveConfiguredModel(model);
+  const resolvedModel = resolveConfiguredModel(model, "light");
 
   const llmResult = await spawnClaude(prompt, resolvedModel);
   const jsonText = extractJson(llmResult.text);

--- a/packages/rex/src/analyze/reshape-reason.ts
+++ b/packages/rex/src/analyze/reshape-reason.ts
@@ -372,6 +372,9 @@ export interface BodyMergeResult {
 /**
  * Use LLM to generate a merged description for a group of hash-suffix duplicate items.
  * Returns a generic description that covers the combined scope of all items.
+ *
+ * Mechanical single-shot call: when no explicit model is given, routes to the
+ * vendor's light-tier model (e.g. haiku) instead of the standard tier.
  */
 export async function reasonForBodyMerge(
   group: PRDItem[],
@@ -397,7 +400,7 @@ export async function reasonForBodyMerge(
     itemSummary,
   ].join("\n");
 
-  const llmResult = await spawnClaude(prompt, model);
+  const llmResult = await spawnClaude(prompt, model, undefined, "light");
   accumulateTokenUsage(tokenUsage, llmResult.tokenUsage);
 
   return {

--- a/packages/rex/src/cli/commands/analyze.ts
+++ b/packages/rex/src/cli/commands/analyze.ts
@@ -626,8 +626,12 @@ async function postProcessProposals(
 
   const loeConfig = await loadLoEConfig(dir, noLlm);
 
-  // Consolidation guard: reduce over-granular LLM output
-  const guardSpin = startSpinner("Checking proposal granularity…");
+  // Consolidation guard: reduce over-granular LLM output.
+  // The guard is a mechanical single-shot pass — it runs on the light tier
+  // unless a model was explicitly provided (--model / rex config).
+  const guardSpin = startSpinner(
+    model ? "Checking proposal granularity…" : "Checking proposal granularity (light tier)…",
+  );
   const guardResult = await applyConsolidationGuard(proposals, loeConfig, model);
   guardSpin.stop();
   if (guardResult.triggered) {
@@ -885,6 +889,9 @@ async function handleAcceptance(
     const assessmentHandler = async (
       targetProposals: Proposal[],
     ): Promise<{ assessments: import("./chunked-review.js").ProposalAssessment[]; formatted: string }> => {
+      // Granularity assessment is a mechanical single-shot pass — it runs
+      // on the light tier unless a model was explicitly provided.
+      if (!model) info("Assessing granularity (light tier)…");
       const r = await assessGranularity(targetProposals, model);
       return {
         assessments: r.assessments,

--- a/packages/rex/src/cli/commands/prune.ts
+++ b/packages/rex/src/cli/commands/prune.ts
@@ -157,18 +157,21 @@ export async function cmdPrune(
         const claudeConfig = await loadClaudeConfig(rexDir);
         setClaudeConfig(claudeConfig);
 
-        // Resolve model: explicit flag > vendor config > default
-        const resolvedModel = resolveConfiguredModel(flags.model);
+        // Resolve model: explicit flag > light-tier resolution (consolidation
+        // is a mechanical single-shot pass, so it runs on the light tier;
+        // only lightModel config or --model overrides it).
+        const resolvedModel = resolveConfiguredModel(flags.model, "light");
         const dryRunVendor = getLLMVendor() ?? DEFAULT_LLM_VENDOR;
         const dryRunModelSource = flags.model
           ? "cli-override" as const
-          : llmConfig.claude?.model || llmConfig.codex?.model || llmConfig.google?.model
+          : llmConfig.claude?.lightModel || llmConfig.codex?.lightModel || llmConfig.google?.lightModel
             ? "configured" as const
             : "default" as const;
         printVendorModelHeader(dryRunVendor, llmConfig, {
           format: flags.format,
           resolvedModel,
           modelSource: dryRunModelSource,
+          tier: "light",
         });
 
         // Pre-flight budget check
@@ -382,18 +385,21 @@ async function consolidateAfterPrune(
     const claudeConfig = await loadClaudeConfig(rexDir);
     setClaudeConfig(claudeConfig);
 
-    // Resolve model: explicit flag > vendor config > default
-    const resolvedModel = resolveConfiguredModel(flags.model);
+    // Resolve model: explicit flag > light-tier resolution (post-prune
+    // consolidation is a mechanical single-shot pass, so it runs on the
+    // light tier; only lightModel config or --model overrides it).
+    const resolvedModel = resolveConfiguredModel(flags.model, "light");
     const vendor = getLLMVendor() ?? DEFAULT_LLM_VENDOR;
     const modelSource = flags.model
       ? "cli-override" as const
-      : llmConfig.claude?.model || llmConfig.codex?.model || llmConfig.google?.model
+      : llmConfig.claude?.lightModel || llmConfig.codex?.lightModel || llmConfig.google?.lightModel
         ? "configured" as const
         : "default" as const;
     printVendorModelHeader(vendor, llmConfig, {
       format: flags.format,
       resolvedModel,
       modelSource,
+      tier: "light",
     });
 
     // Pre-flight budget check

--- a/packages/rex/src/cli/commands/reshape.ts
+++ b/packages/rex/src/cli/commands/reshape.ts
@@ -110,6 +110,9 @@ async function _cmdReshapeCore(
 
   // Resolve model: explicit flag > vendor config > default
   const resolvedModel = resolveConfiguredModel(flags.model);
+  // Mechanical single-shot sub-passes (body merges, group renames) run on the
+  // vendor's light tier. An explicit --model flag still overrides everything.
+  const lightModel = resolveConfiguredModel(flags.model, "light");
   const vendor = getLLMVendor() ?? DEFAULT_LLM_VENDOR;
   const modelSource = flags.model
     ? "cli-override" as const
@@ -232,6 +235,17 @@ async function _cmdReshapeCore(
 
   // LLM body merge: for each accepted hash-suffix MergeAction, generate a merged description
   const { findItem: findItemInTree, updateInTree } = await import("../../core/tree.js");
+  // Surface the tier for the mechanical sub-passes (mirrors the vendor header's
+  // "(light tier)" annotation) — only when they will actually run and the
+  // model was not explicitly overridden.
+  const hasLightSubPasses = reshapeResult.applied.some(
+    (p) =>
+      (p.action.action === "merge" && (p.action as MergeAction).reason === "hash-suffix-duplicate-sibling") ||
+      p.action.action === "group",
+  );
+  if (hasLightSubPasses && !flags.model) {
+    info(`  [hash-suffix] merge/rename sub-passes use model: ${lightModel} (light tier)`);
+  }
   for (const proposal of reshapeResult.applied) {
     if (
       proposal.action.action === "merge" &&
@@ -246,7 +260,7 @@ async function _cmdReshapeCore(
       if (survivorEntry && loserItems.length > 0) {
         const group = [survivorEntry.item, ...loserItems];
         try {
-          const bodyMerge = await reasonForBodyMerge(group, resolvedModel);
+          const bodyMerge = await reasonForBodyMerge(group, lightModel);
           updateInTree(docAfterCompaction.items, mergeAction.survivorId, {
             description: bodyMerge.description,
           });
@@ -280,7 +294,7 @@ async function _cmdReshapeCore(
       };
 
       try {
-        const renameProposal = await proposeGroupRenames(consolidationGroup, resolvedModel);
+        const renameProposal = await proposeGroupRenames(consolidationGroup, lightModel);
         for (const rename of renameProposal.renames) {
           updateInTree(docAfterCompaction.items, rename.id, { title: rename.newTitle });
         }

--- a/packages/rex/tests/unit/analyze/light-tier-routing.test.ts
+++ b/packages/rex/tests/unit/analyze/light-tier-routing.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for light-tier model routing of mechanical single-shot LLM calls.
+ *
+ * Verifies that:
+ * - Sibling renames, group renames, body merges, the consolidation guard,
+ *   and the granularity assessment pass resolve the vendor's light-tier
+ *   model when no explicit model override is given.
+ * - An explicit model (CLI --model flag or upstream-resolved model) always
+ *   wins over weight-based tier resolution.
+ * - `spawnClaude` itself resolves the tier-appropriate model from the weight
+ *   parameter at the single LLM choke point.
+ *
+ * @see packages/llm-client/tests/unit/config.test.ts for the underlying
+ *   resolveVendorModel tier-resolution tests.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TIER_MODELS } from "@n-dx/llm-client";
+import type { PRDItem } from "../../../src/schema/index.js";
+import type { Proposal, ProposalTask } from "../../../src/analyze/propose.js";
+
+// Mock spawnClaude at the llm-bridge choke point before importing the modules
+// under test. reason.js re-exports the bridge, so both the helpers that import
+// spawnClaude from "./reason.js" and reason.ts's own internal bridge import
+// resolve to this mock. The real resolveConfiguredModel (and module-level LLM
+// config state) is kept so the weight-aware resolution path is exercised for
+// helpers that resolve the model themselves before calling spawnClaude.
+vi.mock("../../../src/analyze/llm-bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/analyze/llm-bridge.js")>();
+  return {
+    ...actual,
+    spawnClaude: vi.fn(),
+  };
+});
+
+import { spawnClaude, setLLMConfig } from "../../../src/analyze/llm-bridge.js";
+import { proposeSiblingRenames } from "../../../src/analyze/rename-resolve.js";
+import { proposeGroupRenames } from "../../../src/analyze/propose-group-renames.js";
+import { reasonForBodyMerge } from "../../../src/analyze/reshape-reason.js";
+import { applyConsolidationGuard } from "../../../src/analyze/consolidation-guard.js";
+import { assessGranularity } from "../../../src/analyze/reason.js";
+
+const mockSpawnClaude = vi.mocked(spawnClaude);
+
+const CLAUDE_LIGHT = TIER_MODELS.claude.light; // claude-haiku-4-5
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeItem(id: string, title: string): PRDItem {
+  return {
+    id,
+    title,
+    level: "task",
+    status: "pending",
+    description: `Description for ${title}`,
+  } as PRDItem;
+}
+
+function makeTask(title: string): ProposalTask {
+  return {
+    title,
+    source: "test",
+    sourceFile: "src/x.ts",
+    description: "d",
+    acceptanceCriteria: ["ok"],
+    priority: "medium",
+  };
+}
+
+function makeProposal(title: string, taskCount: number): Proposal {
+  const tasks: ProposalTask[] = [];
+  for (let i = 0; i < taskCount; i++) tasks.push(makeTask(`Task ${i + 1} of ${title}`));
+  return {
+    epic: { title, source: "test" },
+    features: [{ title: `${title} Feature`, source: "test", tasks }],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset module-level LLM config to a bare claude setup (no model overrides).
+  setLLMConfig({ vendor: "claude" });
+});
+
+// ── Sibling renames (rename-resolve.ts) ────────────────────────────────────────
+
+describe("proposeSiblingRenames light-tier routing", () => {
+  const renameResponse = {
+    text: JSON.stringify({ titleA: "New A", titleB: "New B", reasoning: "distinct" }),
+  };
+
+  it("resolves the light-tier model when no explicit model is given", async () => {
+    mockSpawnClaude.mockResolvedValue(renameResponse);
+
+    await proposeSiblingRenames(makeItem("a", "Same"), makeItem("b", "Same"));
+
+    expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe(CLAUDE_LIGHT);
+  });
+
+  it("honors an explicit model override", async () => {
+    mockSpawnClaude.mockResolvedValue(renameResponse);
+
+    await proposeSiblingRenames(makeItem("a", "Same"), makeItem("b", "Same"), "claude-opus-4-7");
+
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe("claude-opus-4-7");
+  });
+
+  it("honors a configured lightModel override for the light tier", async () => {
+    setLLMConfig({ vendor: "claude", claude: { lightModel: "claude-custom-light" } });
+    mockSpawnClaude.mockResolvedValue(renameResponse);
+
+    await proposeSiblingRenames(makeItem("a", "Same"), makeItem("b", "Same"));
+
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe("claude-custom-light");
+  });
+
+  it("does not let the standard-tier model config affect the light tier", async () => {
+    setLLMConfig({ vendor: "claude", claude: { model: "claude-opus-4-7" } });
+    mockSpawnClaude.mockResolvedValue(renameResponse);
+
+    await proposeSiblingRenames(makeItem("a", "Same"), makeItem("b", "Same"));
+
+    // Standard-tier `model` config applies to the standard tier only.
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe(CLAUDE_LIGHT);
+  });
+});
+
+// ── Group renames (propose-group-renames.ts) ───────────────────────────────────
+
+describe("proposeGroupRenames light-tier routing", () => {
+  const groupResponse = {
+    text: JSON.stringify({
+      renames: [
+        { id: "m1", title: "First distinct" },
+        { id: "m2", title: "Second distinct" },
+      ],
+      reasoning: "split",
+    }),
+  };
+  const group = {
+    baseTitle: "Do the thing",
+    members: [
+      { id: "m1", title: "Do the thing" },
+      { id: "m2", title: "Do the thing" },
+    ],
+  };
+
+  it("resolves the light-tier model when no explicit model is given", async () => {
+    mockSpawnClaude.mockResolvedValue(groupResponse);
+
+    await proposeGroupRenames(group);
+
+    expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe(CLAUDE_LIGHT);
+  });
+
+  it("honors an explicit model override", async () => {
+    mockSpawnClaude.mockResolvedValue(groupResponse);
+
+    await proposeGroupRenames(group, "claude-opus-4-7");
+
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe("claude-opus-4-7");
+  });
+});
+
+// ── Body merges (reshape-reason.ts) ────────────────────────────────────────────
+
+describe("reasonForBodyMerge light-tier routing", () => {
+  it("passes the light weight to spawnClaude when no model is given", async () => {
+    mockSpawnClaude.mockResolvedValue({ text: "Merged description." });
+
+    await reasonForBodyMerge([makeItem("a", "Dup (abc123)"), makeItem("b", "Dup (def456)")]);
+
+    expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
+    expect(mockSpawnClaude.mock.calls[0][1]).toBeUndefined();
+    expect(mockSpawnClaude.mock.calls[0][3]).toBe("light");
+  });
+
+  it("forwards an explicit model, which wins over the weight", async () => {
+    mockSpawnClaude.mockResolvedValue({ text: "Merged description." });
+
+    await reasonForBodyMerge([makeItem("a", "Dup")], "claude-opus-4-7");
+
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe("claude-opus-4-7");
+  });
+});
+
+// ── Consolidation guard (consolidation-guard.ts) ───────────────────────────────
+
+describe("applyConsolidationGuard light-tier routing", () => {
+  it("passes the light weight to spawnClaude when triggered without a model", async () => {
+    mockSpawnClaude.mockResolvedValue({
+      text: JSON.stringify([makeProposal("Auth", 1)]),
+      tokenUsage: { input: 10, output: 5 },
+    });
+
+    await applyConsolidationGuard([makeProposal("Auth", 5)], { proposalCeiling: 2 });
+
+    expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
+    expect(mockSpawnClaude.mock.calls[0][1]).toBeUndefined();
+    expect(mockSpawnClaude.mock.calls[0][3]).toBe("light");
+  });
+
+  it("forwards an explicit model, which wins over the weight", async () => {
+    mockSpawnClaude.mockResolvedValue({
+      text: JSON.stringify([makeProposal("Auth", 1)]),
+      tokenUsage: { input: 10, output: 5 },
+    });
+
+    await applyConsolidationGuard([makeProposal("Auth", 5)], { proposalCeiling: 2 }, "claude-opus-4-7");
+
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe("claude-opus-4-7");
+  });
+});
+
+// ── Granularity assessment (reason.ts) ─────────────────────────────────────────
+
+describe("assessGranularity light-tier routing", () => {
+  const assessmentResponse = {
+    text: JSON.stringify([
+      { proposalIndex: 0, recommendation: "keep", reasoning: "fine", issues: [] },
+    ]),
+  };
+
+  it("passes the light weight to spawnClaude when no model is given", async () => {
+    mockSpawnClaude.mockResolvedValue(assessmentResponse);
+
+    await assessGranularity([makeProposal("Auth", 2)]);
+
+    expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
+    expect(mockSpawnClaude.mock.calls[0][1]).toBeUndefined();
+    expect(mockSpawnClaude.mock.calls[0][3]).toBe("light");
+  });
+
+  it("forwards an explicit model, which wins over the weight", async () => {
+    mockSpawnClaude.mockResolvedValue(assessmentResponse);
+
+    await assessGranularity([makeProposal("Auth", 2)], "claude-opus-4-7");
+
+    expect(mockSpawnClaude.mock.calls[0][1]).toBe("claude-opus-4-7");
+  });
+});

--- a/packages/rex/tests/unit/analyze/llm-bridge-weight.test.ts
+++ b/packages/rex/tests/unit/analyze/llm-bridge-weight.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for spawnClaude's weight-aware model resolution at the
+ * llm-bridge choke point. Uses an injected fake client (setClaudeClient) so
+ * no real LLM process or API call is made.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { TIER_MODELS, NEWEST_MODELS } from "@n-dx/llm-client";
+import { spawnClaude, setLLMConfig, setClaudeClient } from "../../../src/analyze/llm-bridge.js";
+
+function captureClient(): { models: string[] } {
+  const captured = { models: [] as string[] };
+  setClaudeClient({
+    mode: "cli",
+    complete: async ({ model }: { prompt: string; model: string }) => {
+      captured.models.push(model);
+      return { text: "ok" };
+    },
+  } as never);
+  return captured;
+}
+
+describe("spawnClaude weight-aware model resolution", () => {
+  beforeEach(() => {
+    // Reset module state (also clears any previously injected client).
+    setLLMConfig({ vendor: "claude" });
+  });
+
+  it("resolves the light-tier model for weight 'light' with no explicit model", async () => {
+    const captured = captureClient();
+
+    await spawnClaude("prompt", undefined, undefined, "light");
+
+    expect(captured.models).toEqual([TIER_MODELS.claude.light]);
+  });
+
+  it("defaults to the standard-tier model when weight is omitted", async () => {
+    const captured = captureClient();
+
+    await spawnClaude("prompt");
+
+    expect(captured.models).toEqual([NEWEST_MODELS.claude]);
+  });
+
+  it("lets an explicit model win over the light weight", async () => {
+    const captured = captureClient();
+
+    await spawnClaude("prompt", "claude-opus-4-7", undefined, "light");
+
+    expect(captured.models).toEqual(["claude-opus-4-7"]);
+  });
+
+  it("honors a configured lightModel for the light weight", async () => {
+    setLLMConfig({ vendor: "claude", claude: { lightModel: "claude-custom-light" } });
+    const captured = captureClient();
+
+    await spawnClaude("prompt", undefined, undefined, "light");
+
+    expect(captured.models).toEqual(["claude-custom-light"]);
+  });
+});


### PR DESCRIPTION
## Summary

Routes mechanical, single-shot LLM calls to the vendor's **light** model tier (`claude-haiku-4-5` / `gpt-5.4-mini` / `gemini-2.0-flash`) instead of the standard model. The tier machinery already existed in `llm-client` (`resolveVendorModel(vendor, config, weight)`) and was proven in sourcevision's enrichment pass 1 — but only two call sites in the monorepo used it. This is the second wave of the **Per-Command Task Weight Classification** feature; the first wave wired `smart-add --fast`.

These are calls with a fixed turn count, machine-verifiable output, and low reasoning demand — roughly 30–50% of rex's LLM call volume, at about ⅓ the input and output price. From the 2026-08 token-usage audit (`docs/analysis/token-usage-audit.md`, findings H8 and R5).

## What changed

**rex — `TaskWeight` through the bridge.** `spawnClaude(prompt, model?, claudeConfig?, weight = "standard")` feeds `resolveConfiguredModel(model, weight)` at the single choke point. Routed to light:

| Call site | Notes |
|---|---|
| `rename-resolve.ts` `proposeSiblingRenames` | resolves light internally |
| `propose-group-renames.ts` | resolves light internally |
| `reshape-reason.ts` `reasonForBodyMerge` | passes `"light"` |
| `consolidation-guard.ts` `applyConsolidationGuard` | passes `"light"` |
| `reason.ts` `assessGranularity` | chunked-review `g` action |
| `guided.ts` | clarify rounds only — spec synthesis stays standard |
| `reshape.ts` / `prune.ts` | resolve a scoped light model for the body-merge / group-rename / consolidate sub-passes; each command's main call stays standard |

`reshape.ts` and `prune.ts` were pre-resolving the standard model upstream and passing it down, so routing the leaf functions alone would have been silently inert.

**hench — commit messages on light.** `proposePreRunCommitMessage` previously sent up to 12 KB of diff to the full-price model to produce a one-line commit subject.

**Tier visibility.** Reuses the existing `printVendorModelHeader` `tier` option: prune headers, the analyze guard spinner, the assessment handler, a reshape sub-pass note, and a hench `detail` line all label light-tier usage.

An explicit `--model` flag or pinned config model short-circuits tier resolution everywhere.

## Known follow-up (please read before merging)

`proposePreRunCommitMessage` **infers** whether an override was given, by comparing the passed model against the config-derived standard resolution. This is a workaround: `cli/commands/run.ts` was off-limits during implementation because `feature/ndx-work-review` is concurrently modifying it. It works and is tested, but has a documented edge case — `--model <exact-standard-default>` is indistinguishable from no flag and gets light.

Once `feature/ndx-work-review` lands, thread an explicit flag or resolved tier from `run.ts` and delete the heuristic. This is inference where an explicit signal belongs, not intentional cleverness.

## Deliberately out of scope

- **Escalation ladder** — separate PRD task; light-tier calls do not yet auto-retry on the standard tier when output fails validation.
- `reasonFromScanResults`, `modify-reason.ts`, smart-add's main path, reshape/reorganize/smart-prune main calls, `adjustGranularity`, decompose — generative or judgment work that stays standard.
- smart-add's call into the consolidation guard still passes its own pre-resolved model, so light routing is inert on that one path; `--fast` already covers smart-add's light path.
- No edits to `llm-client/src/config.ts` or the hench llm-gateway export block — owned by `feature/ndx-work-review` to avoid conflicts.

## Testing

21 new tests across 3 files — 5 rex call sites (light by default, explicit model wins, `lightModel` config wins, standard-tier `model` config does not leak into light resolution), `spawnClaude` weight resolution, and the hench commit path.

`pnpm build` ✓ · `pnpm typecheck` ✓ · full `pnpm test` ✓ (6/6 suites, including `architecture-policy` and `domain-isolation` e2e guards)

Changeset: patch bump for `@n-dx/rex` and `@n-dx/hench`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
