### PR TITLE
Feat/create UI text exchange for sourcevision and others

### DIFF
--- a/.changeset/ask-panel-adoption-markers.md
+++ b/.changeset/ask-panel-adoption-markers.md
@@ -1,0 +1,18 @@
+---
+"@n-dx/web": patch
+---
+
+Mark where the SourceVision Ask panel and its Rex/Hench siblings will land
+
+The PRD gained a "SourceVision Ask Panel" feature — a gated text exchange over
+the analysed project that can explain a finding in plain language and propose
+PRD refinements. The code side of this branch is markers only, no behaviour: a
+placement comment in `SOURCEVISION_TABS` for the gated `Ask` tab, plus adoption
+markers in `domain-rex.ts` and `domain-hench.ts` for the two surfaces that want
+the same panel afterwards.
+
+The Rex and Hench panels are intentionally absent from the PRD. The sequence is
+to build the SourceVision one, generalise it, then lift the shared piece out —
+so the markers record the intent (and, for Rex, that a panel there must reuse
+the existing `withTransaction` apply path rather than adding a second PRD write
+surface) without implying scheduled work.

--- a/.changeset/sourcevision-git-test-timeout.md
+++ b/.changeset/sourcevision-git-test-timeout.md
@@ -1,0 +1,16 @@
+---
+"@n-dx/sourcevision": patch
+---
+
+Stop git-backed sourcevision tests timing out on Windows CI
+
+`branch-work-collector`, `pr-markdown`, and `pr-markdown-reviewer-output` build
+real git repositories in a temp directory. The heaviest tests spend 8-13
+synchronous `git` spawns each — init/config/commit/checkout in the fixture, plus
+the collector's own `rev-parse` and two speculative `git show` calls. Those run
+in 230-540ms locally, but Windows process creation and on-access scanning of the
+temp worktree pushed three of them past vitest's 5000ms default.
+
+Sourcevision was the last package with git-spawning integration tests still on
+that default, so its `testTimeout` now matches hench and rex at 30s. No
+production code changed.

--- a/.rex/prd_tree/cli-developer-tools/adversarial-review-pass-for-ndx-work/index.md
+++ b/.rex/prd_tree/cli-developer-tools/adversarial-review-pass-for-ndx-work/index.md
@@ -17,13 +17,14 @@ lastModifiedBy: "sterling.h@endash.us <sterling.h@endash.us>"
 
 | Title | Status |
 |-------|--------|
+| [Add --review flag and move the diff-approval gate to --approve-diff](./add-review-flag-and-move-the-f7a55c.md) | completed |
+| [Correct the remaining stale entries in MODEL_COSTS](./correct-the-remaining-stale-859237.md) | pending |
+| [Give review its own model tier with a review-model override](./give-review-its-own-model-tier-b889a2.md) | completed |
+| [Merge the review pass's per-turn token usage into the run record](./merge-the-review-pass-s-per-cea4d4.md) | pending |
+| [Resume the work session for the reviewer on --resume](./resume-the-work-session-for-the-2eb560.md) | completed |
+| [Review report transport, parsing, and run-record recording](./review-report-transport-parsing-2f0be1.md) | completed |
+| [Verify the review pass end-to-end against a real ndx work run](./verify-the-review-pass-end-to-0deece.md) | completed |
 | [Add .hench/reviews/ to .gitignore](./add-hench-reviews-to-gitignore.md) | completed |
-| [Add --review flag and move the diff-approval gate to --approve-diff](./add-review-flag-and-move-the-diff.md) | completed |
 | [autoCommit leaves reviewer must-fix repairs uncommitted when the executor self-commits](./autocommit-leaves-reviewer-must-fix.md) | completed |
-| [Correct the remaining stale entries in MODEL_COSTS](./correct-the-remaining-stale-entries-in.md) | completed |
-| [Give review its own model tier with a review-model override](./give-review-its-own-model-tier-with-a.md) | completed |
 | [Post-review full-suite gate skips because filesChanged misses executor and reviewer modifications](./post-review-full-suite-gate-skips.md) | completed |
-| [Resume the work session for the reviewer on --resume](./resume-the-work-session-for-the.md) | completed |
-| [Review report transport, parsing, and run-record recording](./review-report-transport-parsing-and.md) | completed |
 | [Unresolved-findings warning mislabels non-must-fix failures as unrepaired must-fix](./unresolved-findings-warning-mislabels.md) | completed |
-| [Verify the review pass end-to-end against a real ndx work run](./verify-the-review-pass-end-to-end.md) | completed |

--- a/.rex/prd_tree/cli-developer-tools/adversarial-review-pass-for-ndx-work/merge-the-review-pass-s-per-cea4d4.md
+++ b/.rex/prd_tree/cli-developer-tools/adversarial-review-pass-for-ndx-work/merge-the-review-pass-s-per-cea4d4.md
@@ -1,0 +1,11 @@
+---
+id: "cea4d4df-7f07-4b7c-93ca-7a41faf03a4e"
+level: "task"
+title: "Merge the review pass's per-turn token usage into the run record"
+status: "pending"
+priority: "high"
+acceptanceCriteria: []
+description: "runAdversarialReviewPass (cli-loop.ts:1161) adds the reviewer's aggregate usage to run.tokenUsage but never concats result.turnTokenUsage into run.turnTokenUsage — accumulateResult (cli-loop.ts:1024) is the only path that does, and the review pass does not go through it. rex/src/core/token-usage.ts:332 builds usage events from turnTokenUsage when it is non-empty and then `continue`s, never falling back to the aggregate, so the reviewer's spend is invisible to ndx usage and the dashboard rollup.\n\nMeasured on a live --review run (fixture run 5c1e9bee, executor claude-sonnet-4-6, reviewer claude-opus-5): run.tokenUsage.output = 28920, but all 20 turnTokenUsage entries are tagged claude-sonnet-4-6 and sum to 3154 output. `ndx usage` printed the aggregate as the headline (29,082) and the per-turn sum as the per-command line (3,200) in the same report — an 89% under-report — and costed the whole run at Sonnet pricing though ~25.8k of the 28.9k output tokens were billed to opus-5.\n\nThis is the exact outcome the comment at cli-loop.ts:1159-1161 says it exists to prevent (\"leaving it out would make --review look free in ndx usage\"). The aggregate half works; the per-turn half was missed. Fix by appending the reviewer's turnTokenUsage entries (tagged with the review model) to the run, so per-model cost rollups price the reviewer correctly.</description>\n<parameter name=\"source\">Discovered while verifying the review pass end-to-end (task 0deece15)"
+lastModified: "2026-09-01T18:26:44.665Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/cli-developer-tools/hench-init-must-gitignore-hench-db911d.md
+++ b/.rex/prd_tree/cli-developer-tools/hench-init-must-gitignore-hench-db911d.md
@@ -1,0 +1,11 @@
+---
+id: "db911d92-d716-4fa1-b2b8-8823daa82095"
+level: "task"
+title: "hench init must gitignore .hench/locks/ or the first autonomous run self-blocks"
+status: "pending"
+priority: "high"
+acceptanceCriteria: []
+description: "On a freshly `ndx init`-ed project, `ndx work --auto` refuses to start with \"Refusing to start an autonomous run with 1 uncommitted file(s), 0 line(s) changed in the working tree\" — and the tree reads clean to anyone who checks afterwards, so the message looks unreproducible.\n\nCause: hench creates .hench/locks/ at startup (process/limiter.ts, LOCKS_DIR in process/lifecycle.ts:28). The pre-run gate counts files via `git status --porcelain` (listDirtyPaths, shared.ts:849) and lines via `git diff HEAD --numstat` (change-magnitude.ts:72) — so one untracked directory reads as \"1 file, 0 lines\". The lock is cleaned up on exit, which is why the tree is clean by the time the operator looks. Caught mid-run as `?? .hench/locks/`.\n\nrex init writes .gitignore entries for its own generated files (rex/src/cli/commands/init.ts:74). hench init writes none, so .hench/locks/, .hench/runs/ and .hench/usage-cursors/ are all left untracked. This repo never sees it because n-dx's own .gitignore already lists .hench/locks/ at line 6.\n\nFix: have hench init write the same class of entries rex init does (.hench/locks/, .hench/runs/, .hench/usage-cursors/, .hench-commit-msg.txt). Consider also making the gate ignore hench's own state dir, since a lock the run itself created should never count as operator dirt.</description>\n<parameter name=\"source\">Discovered while verifying the review pass end-to-end (task 0deece15)"
+lastModified: "2026-09-01T18:27:00.040Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/index.md
+++ b/.rex/prd_tree/sourcevision/index.md
@@ -2,10 +2,11 @@
 id: "ebe4c082-7e93-44ee-a286-cf01c05dd907"
 level: "epic"
 title: "SourceVision"
-status: "completed"
+status: "pending"
 startedAt: "2026-04-13T18:35:49.604Z"
-completedAt: "2026-03-24T04:16:45.798Z"
 description: "Static analysis engine: file inventory, import graph, zone detection (Louvain community detection), React component catalog, PR markdown generation. Produces .sourcevision/CONTEXT.md and llms.txt for AI consumption.\n\n---\n\nBuild an evaluation harness in tests/gauntlet/ that captures sourcevision's current LLM-driven analysis output (zone enrichment, file classification) as golden fixtures and scores future runs against them. Once the harness exists, optimization PRs (Haiku swap, heuristic-first classifier, payload reduction, raised concurrency, skip-trivial-zones short-circuit, --full pass signature dedup, cached LLM replay, semantic zone-name scoring) become measured changes with eval-score deltas rather than vibes-based judgment. Motivation: sourcevision analyze burns substantial tokens and wall-clock time; multiple optimization paths exist but each carries silent quality regression risk."
+lastModified: "2026-09-01T14:04:12.821Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
 ---
 
 ## Children
@@ -36,6 +37,7 @@ description: "Static analysis engine: file inventory, import graph, zone detecti
 | [PR Markdown View Toggle and Copy UX](./pr-markdown-view-toggle-and-copy-ux/index.md) | completed |
 | [Recursive zone architecture](./recursive-zone-architecture/index.md) | completed |
 | [Resolve critical SourceVision architectural findings](./resolve-critical-sourcevision/index.md) | completed |
+| [SourceVision Ask Panel (text exchange: explain findings, refine the PRD)](./sourcevision-ask-panel-text-exchange/index.md) | pending |
 | [SourceVision Findings Remediation](./sourcevision-findings-remediation/index.md) | completed |
 | [SourceVision Import Graph Visualization Enhancement](./sourcevision-import-graph/index.md) | completed |
 | [SourceVision PR Markdown Artifact-Based Fallback Mode](./sourcevision-pr-markdown-artifact/index.md) | completed |

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/accessibility-and-regression-2c57fe.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/accessibility-and-regression-2c57fe.md
@@ -1,0 +1,25 @@
+---
+id: "2c57fe09-b75e-42e7-ad84-8f634d766e87"
+level: "task"
+title: "Accessibility and regression coverage for the Ask panel"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "a11y"
+  - "testing"
+blockedBy:
+  - "514d0d03-868a-4eaf-abeb-3e2abdd38bd5"
+  - "74c3fee8-3281-4b30-8157-8794ea68aea5"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "The prompt textarea has a programmatic label, and the submit control is reachable and operable by keyboard alone"
+  - "Answer arrival is announced via an aria-live region; the loading state is also announced"
+  - "Copy and Capture controls are keyboard-operable and their success/error feedback is announced"
+  - "Focus is never stolen from the textarea while the user is typing, and focus order remains sensible after an answer renders"
+  - "Colour is not the only signal distinguishing error from success state"
+  - "Tests cover the view's states and the route's contract, and run in the existing web unit suite without a live server or real LLM"
+description: "Bring the panel to the accessibility bar the other SourceVision subviews already meet (see the Web Dashboard Accessibility epic, which covered the PR Markdown tab, file search, and route tree).\n\nAn async text exchange has one a11y requirement the other views do not: the answer arrives after an indeterminate delay, so a screen reader user must be told it arrived without losing their place. That means a live region, not just a rendered result."
+lastModified: "2026-09-01T14:06:01.102Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/add-gated-ask-tab-and-prompt-514d0d.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/add-gated-ask-tab-and-prompt-514d0d.md
@@ -1,0 +1,21 @@
+---
+id: "514d0d03-868a-4eaf-abeb-3e2abdd38bd5"
+level: "task"
+title: "Add gated Ask tab and prompt/response view shell"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "viewer"
+  - "sourcevision"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "SOURCEVISION_TABS gains an \"ask\" entry with featureGate \"sourcevision.ask\"; the tab is hidden when the gate is off"
+  - "The view is registered in view-id.ts, view-routing.ts, and view-registry.ts, and a direct URL to the Ask tab restores it on reload"
+  - "The panel renders a labelled textarea plus submit control, and distinguishes idle, submitting, answered, and error states visually"
+  - "Submitting an empty or whitespace-only prompt is a no-op that does not issue a request"
+  - "A unit test covers the state transitions and the gate-off hidden case"
+description: "Add the \"Ask\" tab to the SourceVision tab registry and the view shell behind it. Mirrors the existing pr-markdown tab: an entry in SOURCEVISION_TABS with an icon, label, minPass, and featureGate of \"sourcevision.ask\", a new view module under packages/web/src/viewer/views/, and registration in view-id.ts / view-routing.ts / view-registry.ts so the tab is deep-linkable like its siblings.\n\nThe shell owns the prompt textarea, the submit control, and the four display states (idle, submitting, answered, error). It does not call the LLM itself -- it consumes the endpoint from the sibling task."
+lastModified: "2026-09-01T14:04:27.870Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/add-post-api-sourcevision-ask-74c3fe.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/add-post-api-sourcevision-ask-74c3fe.md
@@ -1,0 +1,23 @@
+---
+id: "74c3fee8-3281-4b30-8157-8794ea68aea5"
+level: "task"
+title: "Add POST /api/sourcevision/ask backed by analysis context and llm-client"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "server"
+  - "llm"
+  - "sourcevision"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "POST /api/sourcevision/ask accepts { prompt, seed? } and returns { answer, vendor, model, tokens } with a validated request schema"
+  - "All sourcevision reads pass through domain-gateway.ts; the route file contains no direct @n-dx/sourcevision import (domain-isolation.test.js still passes)"
+  - "Vendor and model are resolved from existing project config rather than hardcoded, and the resolved pair is reported in the response"
+  - "A request that outlives the configured timeout, or that hits a rate limit, returns a typed error naming which occurred -- it does not hang or surface a generic 500"
+  - "The answer is grounded in .sourcevision/ data: a unit test with fixture analysis data asserts the assembled context reaches the LLM call"
+  - "A unit test covers the route's success path and each error path"
+description: "Add the server endpoint that answers a question about the analyzed project. Request carries the prompt plus optional seed context (see the explain-a-finding task); response carries the answer text, the vendor/model actually used, and token counts.\n\nContext assembly reads the already-written .sourcevision/ artifacts through packages/web/src/server/domain-gateway.ts -- adding re-exports there rather than importing @n-dx/sourcevision in the route file. The LLM call goes through @n-dx/llm-client (createLLMClient / provider factories), with vendor and model resolved from existing config the same way routes-llm.ts and routes-config.ts already do.\n\nOpen design decision left to implementation: either a small in-process tool-use loop that queries sourcevision lookups on demand, or a single non-agentic call over a pre-assembled context bundle. The bundle approach is cheaper and more predictable; the loop answers a wider range of questions. Whichever is chosen, the endpoint must stay within the sourcevision analysis as its ground truth."
+lastModified: "2026-09-01T14:04:44.087Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/attribute-ask-token-spend-in-8b9c7d.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/attribute-ask-token-spend-in-8b9c7d.md
@@ -1,0 +1,24 @@
+---
+id: "8b9c7d5a-e5fa-409c-a557-1f2d14230766"
+level: "task"
+title: "Attribute Ask token spend in the usage rollup"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "tokens"
+  - "rex"
+  - "observability"
+blockedBy:
+  - "74c3fee8-3281-4b30-8157-8794ea68aea5"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "Every ask records vendor, model, input tokens, output tokens, and cache tokens"
+  - "Recorded ask spend appears in the token-usage view, distinguishable from hench run spend"
+  - "Cache tokens are reported rather than hidden, consistent with the existing hench/rex cache-token reporting"
+  - "A failed or timed-out ask records whatever tokens were actually consumed rather than silently dropping them"
+  - "A unit test asserts an ask's usage reaches the rollup with the correct vendor/model attribution"
+description: "Each ask spends real tokens from an interactive surface that currently has no accounting path -- unlike hench runs, which are recorded under .hench/runs/ and rolled up per PRD item by rex's aggregateItemTokenUsage (exported via rex-gateway.ts:77). Without this task the dashboard's own LLM spend is invisible in the very view that reports token usage.\n\nRecord vendor, model, input/output tokens, and cache tokens per ask, and surface the total in the token-usage view. Follow the cache-token reporting decision already made for hench and rex (report cache tokens rather than hiding them). Whether asks are attributed to a PRD item or reported as a separate dashboard-spend bucket is an open call -- asks are not task-scoped, so a separate bucket is the likely answer."
+lastModified: "2026-09-01T14:05:36.888Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/explain-a-finding-in-plain-a31d22.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/explain-a-finding-in-plain-a31d22.md
@@ -1,0 +1,28 @@
+---
+id: "a31d22af-f520-47c9-b29f-8174e75ef88e"
+level: "task"
+title: "Explain a finding in plain language from the Problems and Suggestions surfaces"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "viewer"
+  - "sourcevision"
+  - "findings"
+  - "llm"
+blockedBy:
+  - "514d0d03-868a-4eaf-abeb-3e2abdd38bd5"
+  - "74c3fee8-3281-4b30-8157-8794ea68aea5"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "Every finding row in the Problems and Suggestions views offers an Explain action"
+  - "Explain navigates to the Ask panel with the finding pre-seeded as structured seed context (type, severity, zone, message, files), not as a pre-written prose prompt"
+  - "The explanation names the actual zone and files from the finding rather than giving generic advice about the finding type"
+  - "The explanation states what a fix would touch, so it is actionable rather than descriptive"
+  - "The explained answer supports the same Copy and Capture-to-PRD actions as a free-form answer"
+  - "Explain works for every finding type and severity present in the fixture data, including findings with no severity set"
+  - "A unit test asserts the seed context reaches the endpoint with the finding's zone and files intact"
+description: "Findings today are presented as classified rows (type, severity, zone, message) via FindingsList in the Problems and Suggestions views. A row tells the user that something is wrong but not what it means for this codebase or what fixing it involves.\n\nAdd an Explain action per finding that opens the Ask panel pre-seeded with that finding as structured seed context -- id, type, severity, zone, message, and the files involved -- and returns a plain-language explanation. The answer should cover what the finding means, why it matters in this specific repository (naming the zone and files, not generic advice), and what a fix would touch.\n\nThe explanation must be grounded in the finding and the analysis data. An explanation that could have been written without reading this repo is a failed explanation, and the acceptance criteria are written to make that testable."
+lastModified: "2026-09-01T14:06:19.441Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/give-each-degraded-mode-a-811a8f.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/give-each-degraded-mode-a-811a8f.md
@@ -1,0 +1,24 @@
+---
+id: "811a8fe1-7efa-4b32-a4ca-ac36d1b753c6"
+level: "task"
+title: "Give each degraded mode a specific, actionable message"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "ux"
+  - "error-handling"
+blockedBy:
+  - "514d0d03-868a-4eaf-abeb-3e2abdd38bd5"
+  - "74c3fee8-3281-4b30-8157-8794ea68aea5"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "With no .sourcevision/ data present, the panel explains that analysis must run first and surfaces the existing analyze/refresh affordance instead of only naming a command"
+  - "With absent or invalid credentials, the message derives from llm-client's authFailureGuidance / VERIFY_CREDENTIALS_STEP, not from new ad-hoc wording"
+  - "Timeout, rate limit, and provider error are each reported as themselves, and the two that are worth retrying offer a retry"
+  - "The prompt text survives every failure so the user never has to retype the question"
+  - "No degraded path renders a bare generic error string; a unit test asserts this for all three modes"
+description: "The panel has three distinct ways to be unusable, and they need three distinct messages -- at parity with the degraded-mode hardening already done for PR Markdown refresh (see the SourceVision PR Markdown Refresh Degraded-Mode Hardening feature and pr-markdown-refresh-diagnostics.ts).\n\n1. No analysis data: .sourcevision/ is missing or empty -- the panel cannot ground an answer. Tell the user to run analyze, and offer the existing refresh/analyze action rather than only naming the command.\n2. Missing or invalid LLM credentials: reuse llm-client's existing authFailureGuidance / VERIFY_CREDENTIALS_STEP rather than inventing new wording.\n3. LLM failure at request time: timeout, rate limit, or provider error, each named as itself, with retry offered where retrying is sensible.\n\nA bare \"request failed\" for any of these is the specific outcome this task exists to prevent."
+lastModified: "2026-09-01T14:05:22.010Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/index.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/index.md
@@ -1,0 +1,39 @@
+---
+id: "d339458a-b5d4-42e1-a4af-20f48a6e22a4"
+level: "feature"
+title: "SourceVision Ask Panel (text exchange: explain findings, refine the PRD)"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "sourcevision"
+  - "ui"
+  - "llm"
+  - "text-exchange"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "An \"Ask\" tab appears on the SourceVision surface behind feature gate `sourcevision.ask`, following the existing `pr-markdown` gating pattern in sourcevision-tabs.ts"
+  - "Submitting a question returns a text answer grounded in the current .sourcevision/ analysis data, not in the model's own assumptions about the repository"
+  - "The answer offers Copy and Capture-to-PRD, and Capture creates a real PRD item under an existing parent"
+  - "A finding from the Problems or Suggestions surface can be sent to the panel and explained in plain language, naming the zone and files involved"
+  - "The exchange can propose refinements to existing PRD items -- not only new items -- and each proposal is applied only after explicit review, through the locked store write path"
+  - "Every failure path (no analysis data, missing credentials, LLM error or timeout) states what is wrong and what to do, never a bare \"request failed\""
+  - "Token spend from an ask is attributed in the usage rollup rather than lost"
+  - "The rex and hench surfaces are untouched, with TODO comments marking where their equivalent panels would later be added"
+description: "A gated \"Ask\" tab on the SourceVision dashboard surface providing a prompt -> response text exchange over the analyzed project. The user types a natural-language question in a textarea; the web server assembles context from the existing .sourcevision/ analysis and calls the LLM through @n-dx/llm-client (web already imports the foundation tier directly at 11 call sites, so no new gateway is required); the answer renders as markdown in the panel.\n\nBeyond free-form Q&A the panel serves two directed uses: (1) explaining a sourcevision finding in plain language, entered from the Problems/Suggestions surfaces, and (2) refining the PRD from the user's feedback and recommendations -- proposing edits to existing items, not only capturing new ones, with every mutation reviewed as a before/after diff before it is written.\n\nScope is the SourceVision surface only. Adoption on the rex and hench surfaces is deliberately out of scope and is marked with TODO comments in packages/web/src/viewer/views/sourcevision-tabs.ts, domain-rex.ts, and domain-hench.ts rather than captured as PRD items.\n\nReuse anchors already in the codebase: the pr-markdown tab gating pattern (sourcevision-tabs.ts:30), the clipboard copy workflow with execCommand fallback and permission-denied handling (pr-markdown.ts:91,308), the confirm-guarded capture-to-PRD action (overview.ts:204 -> POST /api/rex/capture-next-steps), and the rex gateway's resolveStore for in-process PRD writes (rex-gateway.ts:31)."
+lastModified: "2026-09-01T14:04:10.395Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---
+
+## Children
+
+| Title | Status |
+|-------|--------|
+| [Accessibility and regression coverage for the Ask panel](./accessibility-and-regression-2c57fe.md) | pending |
+| [Add gated Ask tab and prompt/response view shell](./add-gated-ask-tab-and-prompt-514d0d.md) | pending |
+| [Add POST /api/sourcevision/ask backed by analysis context and llm-client](./add-post-api-sourcevision-ask-74c3fe.md) | pending |
+| [Attribute Ask token spend in the usage rollup](./attribute-ask-token-spend-in-8b9c7d.md) | pending |
+| [Explain a finding in plain language from the Problems and Suggestions surfaces](./explain-a-finding-in-plain-a31d22.md) | pending |
+| [Give each degraded mode a specific, actionable message](./give-each-degraded-mode-a-811a8f.md) | pending |
+| [Propose and apply PRD refinements from the exchange, diff-reviewed and under the store lock](./propose-and-apply-prd-971901.md) | pending |
+| [Wire Copy and Capture-to-PRD actions on the answer](./wire-copy-and-capture-to-prd-900c51.md) | pending |

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/propose-and-apply-prd-971901.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/propose-and-apply-prd-971901.md
@@ -1,0 +1,30 @@
+---
+id: "971901dd-2c79-4fed-9a1e-763066ef56bf"
+level: "task"
+title: "Propose and apply PRD refinements from the exchange, diff-reviewed and under the store lock"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "rex"
+  - "prd"
+  - "llm"
+  - "concurrency"
+blockedBy:
+  - "514d0d03-868a-4eaf-abeb-3e2abdd38bd5"
+  - "74c3fee8-3281-4b30-8157-8794ea68aea5"
+  - "900c5196-8073-467e-9d43-90919bb781fe"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "The answer can carry a set of proposed mutations to existing PRD items (description, acceptance criteria, priority, parent, merge of a duplicate sibling) alongside its prose"
+  - "Each proposal renders as a before/after diff of exactly the fields it changes, and is accepted or rejected individually"
+  - "Nothing is written to .rex/prd_tree/ until a proposal is explicitly accepted; rejecting all proposals leaves the tree byte-identical"
+  - "Accepted mutations are applied through rex-gateway's resolveStore inside withTransaction, never by a bare read-modify-write"
+  - "A concurrent PRD writer holding the lock causes the apply to fail loudly naming the holder, rather than overwriting that writer's changes"
+  - "A proposal that no longer matches the item on disk (the item changed since the answer was generated) is reported as stale and refused rather than applied blindly"
+  - "An applied refinement is reflected in the PRD views without a server restart"
+  - "Integration coverage asserts the accept path writes through the lock and the reject path writes nothing"
+description: "Let the exchange act on the user's feedback and recommendations about the PRD itself, not only capture new items. The user says what is wrong or missing in an existing item; the answer proposes concrete mutations -- rewrite a description, add or replace acceptance criteria, change priority, reparent, or merge an obvious duplicate sibling -- and the user reviews each one before anything is written.\n\nTwo constraints make this safe rather than dangerous:\n\nReview before write. An edit can destroy existing content in a way a capture cannot: an LLM rewriting acceptance criteria unreviewed is how a PRD quietly loses its history. Every proposal is rendered as a before/after diff of the affected fields, accepted or rejected individually, with nothing written on a bare \"looks good\".\n\nWrite under the lock. This makes the web server another PRD writer alongside ndx work and the MCP tools. Accepted mutations must go through the gateway's store path (rex-gateway.ts resolveStore) inside withTransaction, so a concurrent writer causes a loud failure naming the holder PID rather than a silent clobber -- exactly the guarantee described in the concurrency contract in CLAUDE.md."
+lastModified: "2026-09-01T14:06:39.378Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/wire-copy-and-capture-to-prd-900c51.md
+++ b/.rex/prd_tree/sourcevision/sourcevision-ask-panel-text-exchange/wire-copy-and-capture-to-prd-900c51.md
@@ -1,0 +1,26 @@
+---
+id: "900c5196-8073-467e-9d43-90919bb781fe"
+level: "task"
+title: "Wire Copy and Capture-to-PRD actions on the answer"
+status: "pending"
+priority: "medium"
+tags:
+  - "web"
+  - "viewer"
+  - "rex"
+  - "clipboard"
+blockedBy:
+  - "514d0d03-868a-4eaf-abeb-3e2abdd38bd5"
+  - "74c3fee8-3281-4b30-8157-8794ea68aea5"
+source: "ndx-capture"
+acceptanceCriteria:
+  - "Copy places the raw answer text on the clipboard, falling back to execCommand when navigator.clipboard is unavailable"
+  - "A clipboard permission denial is reported distinctly from a generic copy failure, matching the PR Markdown view's messaging"
+  - "Capture-to-PRD requires an explicit confirm step before any write, and reports the created item and its parent afterwards"
+  - "Capture failure surfaces the reason and leaves the answer text intact and re-copyable"
+  - "Copy/Capture feedback clears itself and does not persist across a new question"
+  - "Unit tests cover copy success, copy fallback, permission denial, and capture confirm/cancel"
+description: "Add the two response actions. Copy reuses the clipboard workflow already proven in the PR Markdown view (pr-markdown.ts:91 fallbackCopyText, :308 handleCopyRawMarkdown) -- navigator.clipboard with an execCommand fallback, permission-denied distinguished from generic failure, and transient success/error feedback -- rather than reimplementing it.\n\nCapture-to-PRD follows the confirm-guarded pattern from the Overview Next Steps panel (overview.ts:204 -> POST /api/rex/capture-next-steps): the user confirms before anything is written, and the result reports what was created and where it landed.\n\nThe shared clipboard logic should be lifted to a reusable helper if that can be done without a new single-consumer module -- see the two-consumer rule in CLAUDE.md."
+lastModified: "2026-09-01T14:05:00.607Z"
+lastModifiedBy: "Sterling H <sterling.h@endash.us>"
+---

--- a/packages/sourcevision/vitest.config.ts
+++ b/packages/sourcevision/vitest.config.ts
@@ -25,5 +25,14 @@ export default defineConfig({
           "tests/e2e/cli-serve.test.ts",
         ]
       : [],
+    // Raised from 5000ms, matching hench and rex. Three suites
+    // (branch-work-collector, pr-markdown, pr-markdown-reviewer-output) build
+    // real git repos in a temp dir: each test spends 8-13 `git` spawns on
+    // init/config/commit/checkout plus the collector's own rev-parse and
+    // `git show` calls. Locally those tests run 230-540ms; on the Windows CI
+    // runner, per-spawn process creation and on-access AV scanning of the temp
+    // worktree multiply that by roughly an order of magnitude, which pushed
+    // the heaviest three past 5 s while the rest of the suite stayed green.
+    testTimeout: 30_000,
   },
 });

--- a/packages/web/src/viewer/views/domain-hench.ts
+++ b/packages/web/src/viewer/views/domain-hench.ts
@@ -13,3 +13,9 @@ export { HenchRunsView } from "./hench-runs.js";
 export { HenchConfigView } from "./hench-config.js";
 export { HenchTemplatesView } from "./hench-templates.js";
 export { AdaptiveOptimizationView } from "./adaptive-optimization.js";
+
+// TODO(ask-panel): a Hench-scoped Ask panel gets exported here once the
+// SourceVision one (PRD feature d339458a) is generalised. Its domain context is
+// run history rather than analysis data ("why did this run fail", "what did
+// this run spend"), so it needs its own context assembly, not just a new tab.
+// Not in the PRD yet by choice; see sourcevision-tabs.ts for the origin marker.

--- a/packages/web/src/viewer/views/domain-rex.ts
+++ b/packages/web/src/viewer/views/domain-rex.ts
@@ -20,3 +20,10 @@ export { ActivityView } from "./activity.js";
 export { TaskAuditView } from "./task-audit.js";
 export { WorkflowOptimizationView } from "./workflow-optimization.js";
 export { MergeGraphView } from "./merge-graph.js";
+
+// TODO(ask-panel): a Rex-scoped Ask panel gets exported here once the
+// SourceVision one (PRD feature d339458a) is generalised. Note that the
+// PRD-refinement half of that feature already writes through
+// rex-gateway's resolveStore under withTransaction, so a Rex-side panel should
+// reuse that apply path rather than growing a second PRD write surface.
+// Not in the PRD yet by choice; see sourcevision-tabs.ts for the origin marker.

--- a/packages/web/src/viewer/views/sourcevision-tabs.ts
+++ b/packages/web/src/viewer/views/sourcevision-tabs.ts
@@ -37,6 +37,14 @@ export const SOURCEVISION_TABS: readonly SourceVisionTab[] = [
   { id: "problems", icon: "\u26A0", label: "Problems", minPass: ENRICHMENT_THRESHOLDS.problems },
   { id: "suggestions", icon: "\u2728", label: "Suggestions", minPass: ENRICHMENT_THRESHOLDS.suggestions },
   { id: "pr-markdown", icon: "\u270D", label: "PR Markdown", minPass: 0, featureGate: "sourcevision.prMarkdown" },
+  // TODO(ask-panel): the gated "Ask" tab lands here -- a prompt/response text
+  // exchange over the analysed project (explain a finding, refine the PRD).
+  // Tracked by PRD feature d339458a "SourceVision Ask Panel".
+  //
+  // Once it works here, the same panel is wanted on the Rex and Hench surfaces.
+  // That is deliberately not tracked in the PRD yet: generalise this one first,
+  // then lift the shared piece out. Adoption markers for the other two domains
+  // are in domain-rex.ts and domain-hench.ts.
 ];
 
 export const SOURCEVISION_TAB_IDS: SourceVisionTabId[] = SOURCEVISION_TABS.map((tab) => tab.id);

--- a/packages/web/tests/helpers/viewer-boot.ts
+++ b/packages/web/tests/helpers/viewer-boot.ts
@@ -1,0 +1,154 @@
+import { vi } from "vitest";
+
+/**
+ * Shared harness for integration tests that boot the *whole* viewer by importing
+ * `src/viewer/main.ts` (which mounts itself into `#app`).
+ *
+ * These tests must unmount what they mount. Clearing `document.body` detaches the
+ * DOM but leaves the Preact tree live with an effect flush still queued: Preact
+ * defers flushes through `requestAnimationFrame` with a `setTimeout(…, 35)`
+ * fallback, and vitest's jsdom has no rAF, so the fallback always runs. A flush
+ * that lands after vitest tears the environment down executes effect bodies with
+ * no `window` on `globalThis`, raising an uncaught `ReferenceError` that fails the
+ * run even though every test passed.
+ */
+
+type PreactRender = typeof import("preact").render;
+
+let mounted: { render: PreactRender; root: HTMLElement } | null = null;
+
+export function createStorageStub(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
+
+export function ensureBrowserStubs(): void {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: createStorageStub(),
+  });
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: globalThis.localStorage,
+  });
+
+  if (typeof window.matchMedia !== "function") {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+
+  if (typeof HTMLElement.prototype.scrollTo !== "function") {
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: () => {},
+    });
+  }
+}
+
+export function jsonResponse(body: unknown, status: number = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function wait(ms: number = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitFor(predicate: () => boolean, timeoutMs: number = 8_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    if (vi.isFakeTimers()) {
+      await vi.advanceTimersByTimeAsync(20);
+    } else {
+      await wait(20);
+    }
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+export function findNavItem(label: string): HTMLElement | null {
+  const navItems = Array.from(document.querySelectorAll(".nav-item"));
+  return (navItems.find((item) => item.textContent?.includes(label)) ?? null) as HTMLElement | null;
+}
+
+/**
+ * Mount the viewer at `url` with `fetchImpl` stubbed in, and wait for the sidebar
+ * to render.
+ *
+ * Any previously booted viewer is torn down first, so repeated boots inside a
+ * single test do not orphan a mounted tree.
+ */
+export async function bootViewer(url: string, fetchImpl: typeof fetch): Promise<void> {
+  await teardownViewer();
+
+  document.body.innerHTML = '<div id="app"></div>';
+  window.history.replaceState({}, "", url);
+  vi.stubGlobal("fetch", fetchImpl);
+
+  vi.resetModules();
+  await import("../../src/viewer/main.js");
+
+  // Take Preact from the registry main.ts just populated. A static top-level
+  // import would resolve to a different instance after vi.resetModules() and would
+  // not own the tree that was just mounted, so it could not unmount it.
+  const { render } = await import("preact");
+  const root = document.getElementById("app");
+  if (root) mounted = { render, root };
+
+  await waitFor(() => document.querySelector(".sidebar") !== null);
+}
+
+/**
+ * Unmount the booted viewer and let any queued effect flush run while jsdom is
+ * still alive. Safe to call when nothing is mounted.
+ */
+export async function teardownViewer(): Promise<void> {
+  if (!mounted) return;
+
+  const { render, root } = mounted;
+  mounted = null;
+
+  // Runs every hook cleanup — removeEventListener, clearInterval, unsubscribes.
+  render(null, root);
+  root.remove();
+
+  // Drain the flush queued by that final render (35ms fallback, so 50ms clears it).
+  if (vi.isFakeTimers()) {
+    await vi.advanceTimersByTimeAsync(50);
+  } else {
+    await wait(50);
+  }
+}

--- a/packages/web/tests/integration/pr-markdown-tab-parity.test.ts
+++ b/packages/web/tests/integration/pr-markdown-tab-parity.test.ts
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  bootViewer,
+  ensureBrowserStubs,
+  findNavItem,
+  jsonResponse,
+  teardownViewer,
+  waitFor,
+} from "../helpers/viewer-boot.js";
 
 interface PrStatePayload {
   signature: string;
@@ -13,104 +21,6 @@ interface MockApiOptions {
   scope?: string | null;
   state?: PrStatePayload;
   markdown?: string | null;
-}
-
-function createStorageStub(): Storage {
-  const store = new Map<string, string>();
-  return {
-    get length() {
-      return store.size;
-    },
-    clear() {
-      store.clear();
-    },
-    getItem(key: string) {
-      return store.get(key) ?? null;
-    },
-    key(index: number) {
-      return Array.from(store.keys())[index] ?? null;
-    },
-    removeItem(key: string) {
-      store.delete(key);
-    },
-    setItem(key: string, value: string) {
-      store.set(key, value);
-    },
-  };
-}
-
-function ensureBrowserStubs(): void {
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: createStorageStub(),
-  });
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: globalThis.localStorage,
-  });
-
-  if (typeof window.matchMedia !== "function") {
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      value: (query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-      }),
-    });
-  }
-
-  if (typeof HTMLElement.prototype.scrollTo !== "function") {
-    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
-      configurable: true,
-      value: () => {},
-    });
-  }
-}
-
-function jsonResponse(body: unknown, status: number = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-function wait(ms: number = 0): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs: number = 8_000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (predicate()) return;
-    if (vi.isFakeTimers()) {
-      await vi.advanceTimersByTimeAsync(20);
-    } else {
-      await wait(20);
-    }
-  }
-  throw new Error(`Timed out after ${timeoutMs}ms`);
-}
-
-function findNavItem(label: string): HTMLElement | null {
-  const navItems = Array.from(document.querySelectorAll(".nav-item"));
-  return (navItems.find((item) => item.textContent?.includes(label)) ?? null) as HTMLElement | null;
-}
-
-async function bootViewer(url: string, fetchImpl: typeof fetch): Promise<void> {
-  document.body.innerHTML = '<div id="app"></div>';
-  window.history.replaceState({}, "", url);
-  vi.stubGlobal("fetch", fetchImpl);
-
-  vi.resetModules();
-  await import("../../src/viewer/main.js");
-
-  await waitFor(() => document.querySelector(".sidebar") !== null);
 }
 
 function createMockApi(options: MockApiOptions = {}): typeof fetch {
@@ -165,7 +75,8 @@ describe("PR Markdown tab parity integration", { timeout: 120_000 }, () => {
     vi.useRealTimers();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await teardownViewer();
     document.body.innerHTML = "";
     vi.unstubAllGlobals();
     vi.useRealTimers();
@@ -242,6 +153,19 @@ describe("PR Markdown tab parity integration", { timeout: 120_000 }, () => {
 
     await bootViewer("/pr-markdown", failingFetch);
     await waitFor(() => document.body.textContent?.includes("Unable to load PR markdown") ?? false);
+  });
+
+  // Guards the boot harness itself: a mounted viewer that outlives the test file
+  // flushes its effects after vitest tears jsdom down, which raises an uncaught
+  // "window is not defined" and fails the run even when every test passes.
+  it("unmounts the viewer on teardown so no effects outlive the test", async () => {
+    await bootViewer("/pr-markdown", createMockApi());
+    expect(document.querySelector(".sidebar")).not.toBeNull();
+
+    await teardownViewer();
+
+    expect(document.getElementById("app")).toBeNull();
+    expect(document.querySelector(".sidebar")).toBeNull();
   });
 
   it("does not render a manual refresh button", async () => {

--- a/packages/web/tests/integration/token-usage-route-regression.test.ts
+++ b/packages/web/tests/integration/token-usage-route-regression.test.ts
@@ -1,101 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  bootViewer,
+  ensureBrowserStubs,
+  jsonResponse,
+  teardownViewer,
+  waitFor,
+} from "../helpers/viewer-boot.js";
 
 interface MockApiOptions {
   scope?: string | null;
-}
-
-function createStorageStub(): Storage {
-  const store = new Map<string, string>();
-  return {
-    get length() {
-      return store.size;
-    },
-    clear() {
-      store.clear();
-    },
-    getItem(key: string) {
-      return store.get(key) ?? null;
-    },
-    key(index: number) {
-      return Array.from(store.keys())[index] ?? null;
-    },
-    removeItem(key: string) {
-      store.delete(key);
-    },
-    setItem(key: string, value: string) {
-      store.set(key, value);
-    },
-  };
-}
-
-function ensureBrowserStubs(): void {
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: createStorageStub(),
-  });
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: globalThis.localStorage,
-  });
-
-  if (typeof window.matchMedia !== "function") {
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      value: (query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-      }),
-    });
-  }
-
-  if (typeof HTMLElement.prototype.scrollTo !== "function") {
-    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
-      configurable: true,
-      value: () => {},
-    });
-  }
-}
-
-function jsonResponse(body: unknown, status: number = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-function wait(ms: number = 0): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs: number = 8_000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (predicate()) return;
-    if (vi.isFakeTimers()) {
-      await vi.advanceTimersByTimeAsync(20);
-    } else {
-      await wait(20);
-    }
-  }
-  throw new Error(`Timed out after ${timeoutMs}ms`);
-}
-
-async function bootViewer(url: string, fetchImpl: typeof fetch): Promise<void> {
-  document.body.innerHTML = '<div id="app"></div>';
-  window.history.replaceState({}, "", url);
-  vi.stubGlobal("fetch", fetchImpl);
-
-  vi.resetModules();
-  await import("../../src/viewer/main.js");
-
-  await waitFor(() => document.querySelector(".sidebar") !== null);
 }
 
 function createMockApi(options: MockApiOptions = {}): typeof fetch {
@@ -155,7 +69,8 @@ describe("token usage route regression", { timeout: 120_000 }, () => {
     vi.useRealTimers();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await teardownViewer();
     document.body.innerHTML = "";
     vi.unstubAllGlobals();
     vi.useRealTimers();

--- a/tests/e2e/architecture-policy.test.js
+++ b/tests/e2e/architecture-policy.test.js
@@ -115,6 +115,13 @@ const SKIP_DIRS = new Set([
   // <name>/` prefix the ALLOWED list doesn't recognize, and reports it as
   // a violation of a rule the real, committed file already satisfies.
   ".claude",
+  // Same category: `.local_testing/` is gitignored scratch space for local
+  // harness runs (`.gitignore` un-ignores only README.md, the Dockerfiles,
+  // docker-compose.yml, run-gauntlet.*, test-base-commands.sh and
+  // .dockerignore — none of which `walk()` collects, since it only takes
+  // .ts/.js/.mjs). A throwaway fixture project left behind in there was
+  // failing this policy on setup scripts that are not committed source.
+  ".local_testing",
 ]);
 
 function walk(dir, files = []) {


### PR DESCRIPTION
## Update LLM model catalogs to current vendor releases

  Refreshes every vendor catalog in `@n-dx/llm-client` and the orchestration-tier
  catalog, adds Gemini to the dashboard, and clears out stale docs the audit
  surfaced along the way.

  ### Model catalog (`llm-client`, `core`)
  - **Claude:** add `claude-opus-5`, `claude-opus-4-8`, and a `fable` alias for
    `claude-fable-5`; `opus` alias now resolves to `claude-opus-5`; heavy tier
    moves to Opus 5; context windows and pricing updated (Sonnet 4.6 / Opus 4.7
    now 1M-context, Opus 4.7 repriced to $5/$25).
  - **Codex:** newest model is `gpt-5.6-terra`; light tier `gpt-5.6-luna`; new
    heavy tier `gpt-5.6-sol`. Retired IDs (`gpt-5.4`, `gpt-5.4-mini`,
    `gpt-5.3-codex`, `gpt-5.2`) remap to OpenAI's stated replacements so pinned
    configs keep working; `gpt-5.5` stays selectable.
  - **Google:** standard tier moves to `gemini-3.7-flash`, light to
    `gemini-3.5-flash-lite`; `gemini-3.1-pro-preview` deliberately excluded
    (preview IDs are unstable).
  - Review-pass default (`REVIEW_MODELS.claude`) moves to `claude-opus-5`.

  ### Web
  - Gemini support in the dashboard (provider view, routes, tests).

  ### Docs
  - Zone-governance docs no longer hardcode Louvain zone IDs/metrics — they
    point at live `ndx analyze` output instead; package-specific governance
    moved to per-package `CLAUDE.md` files.
  - 15 dated audit/discovery docs archived under `docs/archive/` with an index;
    6 superseded audits deleted; `TESTING.md` gains a canonical-source banner.
  - Package-naming docs corrected: all packages are `@n-dx/`-scoped; unscoped
    names are bin aliases only (changesets must use scoped names).

  ### Tests
  - Hench run-change-detector freshness-window flakes fixed by pinning mtimes
    deterministically instead of racing the 16 ms granularity window.
  - Catalog contract tests, init-llm, and review-model expectations aligned
    with the new catalog.